### PR TITLE
Change master node's vpu and volume to decrease disk IO latency of etcd

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -22,11 +22,11 @@ variable master_memory {
     type = number
 }
 variable master_boot_size {
-    default = 100
+    default = 500
     type = number
 }
 variable master_boot_volume_vpus_per_gb {
-    default = 20
+    default = 60
     type = number
 }
 variable worker_count {


### PR DESCRIPTION
To sustain decent performance of etcd, we need to increase boot volume size and VPU of master node. 