### PR TITLE
Update to a medium-sized cluster for dev-preview Terraform 

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -88,19 +88,16 @@ variable "public_cidr" {
 variable "image_bucket_name" {
   type        = string
   description = "Bucket name of the image"
-  default     = ""
  }
 
  variable "image_name" {
   type        = string
   description = "Image name"
-  default     = ""
  }
 
  variable "image_bucket_namespace" {
   type        = string
   description = "Bucket namespace"
-  default     = ""
  }
 
 


### PR DESCRIPTION
Update the cluster to a medium-sized cluster which follows the config of conformance testing
- Change the VPU and the boot volume size of master nodes to decrease disk IO latency of ETCD. 
- Provision a LB for port 22624 because when new nodes are added to existing clusters, the ignition is downloaded from the port 22624.
- Fix some typos and syntax issues; Improve readability in the Terrafrom script.