### PR TITLE
Additional Terraform Provider Block to Support Multi-region Provisioning 

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -1,8 +1,15 @@
-## Default region
+## Home region
 variable home_region { 
     type = string
     description = "The region identifier of the home region where the tenancy's IAM and compartment resources are defined. For more detail regarding region identifiers, please visit https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm . "
 }
+
+## Infra Region
+variable infrastructure_region {
+    type = string 
+    description = "The region identifier of the region where the networking and computing resources are defined. For more detail regarding region identifiers, please visit https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm . "
+}
+
 variable zone_dns {
     type        = string
     description = "The name of cluster's DNS zone. This name must be the same as what was specified during OpenShift ISO creation."
@@ -108,9 +115,15 @@ variable "enable_private_dns" {
   default     = false
 }
 
-#Provider
+# Reginal Infrastructure Terraform Provider
 provider oci {
-	region = var.home_region
+	region = var.infrastructure_region
+}
+
+# Home Region Terraform Provider 
+provider oci {
+	alias  = "home"
+  region = var.home_region
 }
 
 locals {
@@ -130,6 +143,7 @@ resource oci_identity_tag_namespace openshift_tags {
   description    = "Used for track openshift related resources and policies"
   is_retired     = "false"
   name           = "openshift-${var.cluster_name}"
+  provider       = oci.home
 }
 
 resource oci_identity_tag openshift_instance_role {
@@ -145,6 +159,7 @@ resource oci_identity_tag openshift_instance_role {
       "worker",
     ]
   }
+  provider         = oci.home
 }
 
 data "oci_core_compute_global_image_capability_schemas" "image_capability_schemas" {
@@ -557,6 +572,7 @@ resource "oci_identity_dynamic_group" "openshift_master_nodes" {
     description    = "OpenShift master nodes" 
     matching_rule  = "all {instance.compartment.id='${var.compartment_ocid}', tag.openshift-${var.cluster_name}.instance-role.value='master'}"
     name           = "${var.cluster_name}_master_nodes"
+    provider       = oci.home
 }
 
 resource "oci_identity_policy" "openshift_master_nodes" {
@@ -570,6 +586,7 @@ resource "oci_identity_policy" "openshift_master_nodes" {
         "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to use virtual-network-family in compartment id ${var.compartment_ocid}",
         "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage load-balancers in compartment id ${var.compartment_ocid}",
     ]
+    provider       = oci.home
 }
 
 resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
@@ -577,6 +594,7 @@ resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
   description    = "OpenShift worker nodes"
   matching_rule  = "all {instance.compartment.id='${var.compartment_ocid}', tag.openshift-${var.cluster_name}.instance-role.value='worker'}"
   name           = "${var.cluster_name}_worker_nodes"
+  provider       = oci.home
 }
 
 resource oci_dns_zone openshift {


### PR DESCRIPTION
Use single Terraform configuration to create Oracle Cloud Infrastructure (OCI) resources in multiple regions.
- Home Region: the region where the tenancy's IAM and compartment resources are defined. 
- Infra Region: the region where networking and computing resources are defined.

Screenshot of current UI
<img width="989" alt="Screenshot 2023-12-05 at 9 56 23 AM" src="https://github.com/oracle-quickstart/oci-openshift/assets/147108107/018b84b0-babe-47cd-9ed6-b2e678618a24">


Testing result 
<img width="982" alt="Screenshot 2023-12-05 at 9 55 49 AM" src="https://github.com/oracle-quickstart/oci-openshift/assets/147108107/49675674-674b-4b4c-87d1-10dcb5c21577">
<img width="936" alt="Screenshot 2023-12-05 at 9 55 58 AM" src="https://github.com/oracle-quickstart/oci-openshift/assets/147108107/91306aec-d290-466a-b00e-8c59f659dd4b">
