### PR TITLE
Additional blocks to automate region selection

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -111,6 +111,10 @@ provider oci {
 	region = var.region
 }
 
+data "oci_identity_tenancy" "tenancy" {
+  tenancy_id = var.tenancy_ocid
+}
+
 data oci_identity_region_subscriptions region_subscriptions {
   tenancy_id = var.tenancy_ocid
   filter {

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -1,8 +1,15 @@
-## Default region
+## Home region
 variable home_region { 
     type = string
     description = "The region identifier of the home region where the tenancy's IAM and compartment resources are defined. For more detail regarding region identifiers, please visit https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm . "
 }
+
+## Infra Region
+variable infrastructure_region {
+    type = string 
+    description = "The region identifier of the region where the networking and computing resources are defined. For more detail regarding region identifiers, please visit https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm . "
+}
+
 variable zone_dns {
     type        = string
     description = "The name of cluster's DNS zone. This name must be the same as what was specified during OpenShift ISO creation."
@@ -108,9 +115,15 @@ variable "enable_private_dns" {
   default     = false
 }
 
-#Provider
+# Reginal Infrastructure Terraform Provider
 provider oci {
-	region = var.home_region
+	region = var.infrastructure_region
+}
+
+# Home Region Terraform Provider 
+provider oci {
+	alias  = "home"
+  region = var.home_region
 }
 
 locals {
@@ -130,6 +143,7 @@ resource oci_identity_tag_namespace openshift_tags {
   description    = "Used for track openshift related resources and policies"
   is_retired     = "false"
   name           = "openshift-${var.cluster_name}"
+  provider       = oci.home
 }
 
 resource oci_identity_tag openshift_instance_role {
@@ -145,6 +159,7 @@ resource oci_identity_tag openshift_instance_role {
       "worker",
     ]
   }
+  provider         = oci.home
 }
 
 data "oci_core_compute_global_image_capability_schemas" "image_capability_schemas" {
@@ -557,6 +572,7 @@ resource "oci_identity_dynamic_group" "openshift_master_nodes" {
     description    = "OpenShift master nodes" 
     matching_rule  = "all {instance.compartment.id='${var.compartment_ocid}', tag.openshift-${var.cluster_name}.instance-role.value='master'}"
     name           = "${var.cluster_name}_master_nodes"
+    provider       = oci.home
 }
 
 resource "oci_identity_policy" "openshift_master_nodes" {
@@ -570,6 +586,7 @@ resource "oci_identity_policy" "openshift_master_nodes" {
         "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to use virtual-network-family in compartment id ${var.compartment_ocid}",
         "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage load-balancers in compartment id ${var.compartment_ocid}",
     ]
+    provider       = oci.home
 }
 
 resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
@@ -577,6 +594,7 @@ resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
   description    = "OpenShift worker nodes"
   matching_rule  = "all {instance.compartment.id='${var.compartment_ocid}', tag.openshift-${var.cluster_name}.instance-role.value='worker'}"
   name           = "${var.cluster_name}_worker_nodes"
+  provider       = oci.home
 }
 
 resource oci_dns_zone openshift {

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -1,5 +1,5 @@
 ## Infra Region or Default Region of the Current RMS Stack
-variable "infrastructure_region" {}
+variable "region" {}
 
 variable zone_dns {
     type        = string
@@ -108,14 +108,14 @@ variable "enable_private_dns" {
 
 # Reginal Infrastructure Terraform Provider
 provider oci {
-	region = var.infrastructure_region
+	region = var.region
 }
 
 data oci_identity_region_subscriptions region_subscriptions {
   tenancy_id = var.tenancy_ocid
   filter {
     name   = "region_name"
-    values = [var.infrastructure_region]
+    values = [var.region]
   }
 }
 data oci_identity_regions regions {}


### PR DESCRIPTION
- Dynamically retrieve home region information by DataSource blocks.
- Add Additional Provider block for IAM resources
- Automatically fill out variable "region" for better customer experiences.


So now users only have to manually enter three variables which are cluster name, domain name, and ISO PAR link.
<img width="304" alt="Screenshot 2023-12-05 at 1 41 34 PM" src="https://github.com/oracle-quickstart/oci-openshift/assets/147108107/6c44108e-93ef-464c-b447-37297f92827f">

Testing Results in ORD(non-home region) and SJC (home region). 
<img width="1007" alt="Screenshot 2023-12-05 at 2 15 25 PM" src="https://github.com/oracle-quickstart/oci-openshift/assets/147108107/ab6f0fc8-511d-4f7a-9fd1-41f21b2e9fc3">
<img width="1011" alt="Screenshot 2023-12-05 at 2 15 44 PM" src="https://github.com/oracle-quickstart/oci-openshift/assets/147108107/447b817b-1888-4062-8f37-bba91385c990">




