### PR TITLE
update infrastructure TF with latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,20 @@ See the following articles for installation instructions:
         - Load balancers NSG
         - Cluster control plane NSG
         - Compute nodes NSG
-- **Network Load Balancer (NLB)**
+- **Application Load Balancers**:
+    - Internal
+        - serves "api-int"
+    - External
+        - serves "api" and "*.apps"
 - **OCI Identity Resources**:
     - Dynamic groups
     - Policies
 - **DNS Resources**:
     - oci_dns_zone
-    - oci_dns_rrset (Two entries)
+    - oci_dns_rrset (Three entries)
+        - api
+        - api-int
+        - *.apps
 - **Compute Configurations**:
     - Master Instance Configuration
     - Worker Instance Configuration

--- a/README.md
+++ b/README.md
@@ -54,5 +54,7 @@ See the following articles for installation instructions:
 - **Compute Configurations**:
     - Master Instance Configuration
     - Worker Instance Configuration
-- **Compute Pools**: Pools of master and worker nodes.
+- **Compute Pools**: 
+    - master nodes
+    - worker nodes
 

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -152,6 +152,7 @@ locals {
   all_protocols                   = "all"
   anywhere                        = "0.0.0.0/0"
   create_openshift_instance_pools = true
+  pool_formatter_id = join("", ["$", "{launchCount}"])
 }
 
 data "oci_identity_availability_domain" "availability_domain" {
@@ -787,6 +788,8 @@ resource "oci_core_instance_pool" "master_nodes" {
   compartment_id            = var.compartment_ocid
   display_name              = "${var.cluster_name}-master"
   instance_configuration_id = oci_core_instance_configuration.master_node_config[0].id
+  instance_display_name_formatter = "${var.cluster_name}-master-${local.pool_formatter_id}"
+  instance_hostname_formatter     = "${var.cluster_name}-master-${local.pool_formatter_id}"
   load_balancers {
     backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_external.name
     load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id
@@ -865,6 +868,8 @@ resource "oci_core_instance_pool" "worker_nodes" {
   compartment_id            = var.compartment_ocid
   display_name              = "${var.cluster_name}-worker"
   instance_configuration_id = oci_core_instance_configuration.worker_node_config[0].id
+  instance_display_name_formatter = "${var.cluster_name}-worker-${local.pool_formatter_id}"
+  instance_hostname_formatter     = "${var.cluster_name}-worker-${local.pool_formatter_id}"
   load_balancers {
     backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
     load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -1,129 +1,129 @@
 ## Infra Region or Default Region of the Current RMS Stack
 variable "region" {}
- 
-variable zone_dns {
-    type        = string
-    description = "The name of cluster's DNS zone. This name must be the same as what was specified during OpenShift ISO creation."
+
+variable "zone_dns" {
+  type        = string
+  description = "The name of cluster's DNS zone. This name must be the same as what was specified during OpenShift ISO creation."
 }
-variable master_count {
-    default     = 3
-    type        = number
-    description = "The number of master nodes in the cluster. The default value is 3. "
+variable "master_count" {
+  default     = 3
+  type        = number
+  description = "The number of master nodes in the cluster. The default value is 3. "
 }
-variable master_shape {
-    default     = "VM.Standard.E4.Flex"
-    description = "Compute shape of the master nodes. The default shape is VM.Standard.E4.Flex. For more detail regarding compute shapes, please visit https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm ."
+variable "master_shape" {
+  default     = "VM.Standard.E4.Flex"
+  description = "Compute shape of the master nodes. The default shape is VM.Standard.E4.Flex. For more detail regarding compute shapes, please visit https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm ."
 }
-variable master_ocpu {
-    default     = 4
-    type        = number
-    description = "The number of OCPUs available for the shape of each master node. The default value is 4. "
+variable "master_ocpu" {
+  default     = 4
+  type        = number
+  description = "The number of OCPUs available for the shape of each master node. The default value is 4. "
 }
-variable master_memory {
-    default     = 16
-    type        = number
-    description = "The amount of memory available for the shape of each master node, in gigabytes. The default value is 16. "
+variable "master_memory" {
+  default     = 16
+  type        = number
+  description = "The amount of memory available for the shape of each master node, in gigabytes. The default value is 16. "
 }
-variable master_boot_size {
-    default     = 1024
-    type        = number
-    description = "The size of the boot volume of each master node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 1024 GB. "
+variable "master_boot_size" {
+  default     = 1024
+  type        = number
+  description = "The size of the boot volume of each master node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 1024 GB. "
 }
-variable master_boot_volume_vpus_per_gb {
-    default     = 90
-    type        = number
-    description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each master node. The default value is 90. "
+variable "master_boot_volume_vpus_per_gb" {
+  default     = 90
+  type        = number
+  description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each master node. The default value is 90. "
 }
-variable worker_count {
-    default     = 4
-    type        = number
-    description = "The number of worker nodes in the cluster. The default value is 4. "
+variable "worker_count" {
+  default     = 3
+  type        = number
+  description = "The number of worker nodes in the cluster. The default value is 4. "
 }
-variable worker_shape {
-    default     = "VM.Standard.E4.Flex"
-    description = "Compute shape of the worker nodes. The default shape is VM.Standard.E4.Flex. For more detail regarding compute shapes, please visit https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm "
+variable "worker_shape" {
+  default     = "VM.Standard.E4.Flex"
+  description = "Compute shape of the worker nodes. The default shape is VM.Standard.E4.Flex. For more detail regarding compute shapes, please visit https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm "
 }
-variable worker_ocpu {
-    default     = 4
-    type        = number
-    description = "The number of OCPUs available for the shape of each worker node. The default value is 4. "
+variable "worker_ocpu" {
+  default     = 4
+  type        = number
+  description = "The number of OCPUs available for the shape of each worker node. The default value is 4. "
 }
-variable worker_boot_volume_vpus_per_gb {
-    default     = 30
-    type        = number
-    description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each worker node. The default value is 30. "
+variable "worker_boot_volume_vpus_per_gb" {
+  default     = 30
+  type        = number
+  description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each worker node. The default value is 30. "
 }
-variable worker_memory {
-    default     = 16
-    type        = number
-    description = "The amount of memory available for the shape of each worker node, in gigabytes. The default value is 16."
+variable "worker_memory" {
+  default     = 16
+  type        = number
+  description = "The amount of memory available for the shape of each worker node, in gigabytes. The default value is 16."
 }
-variable worker_boot_size {
-    default     = 100
-    type        = number
-    description = "The size of the boot volume of each worker node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 100 GB."
+variable "worker_boot_size" {
+  default     = 100
+  type        = number
+  description = "The size of the boot volume of each worker node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 100 GB."
 }
-variable load_balancer_shape_details_maximum_bandwidth_in_mbps {
-  default = 500
-  type = number
+variable "load_balancer_shape_details_maximum_bandwidth_in_mbps" {
+  default     = 500
+  type        = number
   description = "Bandwidth in Mbps that determines the maximum bandwidth (ingress plus egress) that the load balancer can achieve. The values must be between minimumBandwidthInMbps and 8000"
 }
-variable load_balancer_shape_details_minimum_bandwidth_in_mbps {
-  default = 10
-  type = number
+variable "load_balancer_shape_details_minimum_bandwidth_in_mbps" {
+  default     = 10
+  type        = number
   description = " Bandwidth in Mbps that determines the total pre-provisioned bandwidth (ingress plus egress). The values must be between 10 and the maximumBandwidthInMbps"
 }
 variable "tenancy_ocid" {
-    type        = string
-    description = "The ocid of the current tenancy."
+  type        = string
+  description = "The ocid of the current tenancy."
 }
- 
+
 ## Openshift infrastructure compartment
-variable compartment_ocid {
-    type        = string
-    description = "The ocid of the compartment where you wish to create the OpenShift cluster."
+variable "compartment_ocid" {
+  type        = string
+  description = "The ocid of the compartment where you wish to create the OpenShift cluster."
 }
- 
+
 ## Openshift cluster name
-variable cluster_name {
-    type        = string
-    description = "The name of your OpenShift cluster. It should be the same as what was specified when creating the OpenShift ISO and it should be DNS compatible."
+variable "cluster_name" {
+  type        = string
+  description = "The name of your OpenShift cluster. It should be the same as what was specified when creating the OpenShift ISO and it should be DNS compatible."
 }
- 
+
 variable "vcn_cidr" {
-  default = "10.0.0.0/16"
+  default     = "10.0.0.0/16"
   description = "The IPv4 CIDR blocks for the VCN of your OpenShift Cluster. The default value is 10.0.0.0/16. "
 }
 variable "private_cidr" {
-  default = "10.0.16.0/20"
+  default     = "10.0.16.0/20"
   description = "The IPv4 CIDR blocks for the private subnet of your OpenShift Cluster. The default value is 10.0.16.0/20. "
 }
 variable "public_cidr" {
-  default = "10.0.0.0/20"
+  default     = "10.0.0.0/20"
   description = "The IPv4 CIDR blocks for the public subnet of your OpenShift Cluster. The default value is 10.0.0.0/20. "
 }
- 
+
 variable "openshift_image_source_uri" {
   type        = string
   description = "The OCI Object Storage URL for the OpenShift image. Before provisioning resources through this Resource Manager stack, users should upload the OpenShift image to OCI Object Storage, create a pre-authenticated requests (PAR) uri, and paste the uri to this block. For more detail regarding Object storage and PAR, please visit https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm and https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingpreauthenticatedrequests.htm ."
 }
- 
+
 variable "enable_private_dns" {
   type        = bool
   description = "If the switch is enabled, a private DNS zone will be created, and users should edit the /etc/hosts file for resolution. Otherwise, a public DNS zone will be created based on the given domain."
   default     = false
 }
- 
+
 # Reginal Infrastructure Terraform Provider
-provider oci {
-    region = var.region
+provider "oci" {
+  region = var.region
 }
- 
+
 data "oci_identity_tenancy" "tenancy" {
   tenancy_id = var.tenancy_ocid
 }
- 
-data oci_identity_region_subscriptions region_subscriptions {
+
+data "oci_identity_region_subscriptions" "region_subscriptions" {
   tenancy_id = var.tenancy_ocid
   filter {
     name   = "region_name"
@@ -131,44 +131,44 @@ data oci_identity_region_subscriptions region_subscriptions {
   }
 }
 
-data oci_identity_regions regions {}
+data "oci_identity_regions" "regions" {}
 
 locals {
   region_map = {
     for r in data.oci_identity_regions.regions.regions :
     r.key => r.name
   }
- 
+
   home_region = lookup(local.region_map, data.oci_identity_tenancy.tenancy.home_region_key)
 }
- 
+
 # Home Region Terraform Provider
-provider oci {
-    alias  = "home"
+provider "oci" {
+  alias  = "home"
   region = local.home_region
 }
- 
+
 locals {
-  all_protocols = "all"
-  anywhere      = "0.0.0.0/0"
+  all_protocols                   = "all"
+  anywhere                        = "0.0.0.0/0"
   create_openshift_instance_pools = true
 }
- 
-data oci_identity_availability_domain availability_domain {
+
+data "oci_identity_availability_domain" "availability_domain" {
   compartment_id = var.compartment_ocid
   ad_number      = "1"
 }
- 
+
 ##Defined tag namespace. Use to mark instance roles and configure instance policy
-resource oci_identity_tag_namespace openshift_tags {
+resource "oci_identity_tag_namespace" "openshift_tags" {
   compartment_id = var.compartment_ocid
   description    = "Used for track openshift related resources and policies"
   is_retired     = "false"
   name           = "openshift-${var.cluster_name}"
   provider       = oci.home
 }
- 
-resource oci_identity_tag openshift_instance_role {
+
+resource "oci_identity_tag" "openshift_instance_role" {
   description      = "Describe instance role inside OpenShift cluster"
   is_cost_tracking = "false"
   is_retired       = "false"
@@ -176,52 +176,52 @@ resource oci_identity_tag openshift_instance_role {
   tag_namespace_id = oci_identity_tag_namespace.openshift_tags.id
   validator {
     validator_type = "ENUM"
-    values         = [
+    values = [
       "master",
       "worker",
     ]
   }
-  provider         = oci.home
+  provider = oci.home
 }
- 
+
 data "oci_core_compute_global_image_capability_schemas" "image_capability_schemas" {
 }
- 
+
 locals {
   global_image_capability_schemas = data.oci_core_compute_global_image_capability_schemas.image_capability_schemas.compute_global_image_capability_schemas
-  image_schema_data               = {
+  image_schema_data = {
     "Compute.Firmware" = "{\"values\": [\"UEFI_64\"],\"defaultValue\": \"UEFI_64\",\"descriptorType\": \"enumstring\",\"source\": \"IMAGE\"}"
   }
 }
- 
+
 resource "oci_core_image" "openshift_image" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   display_name   = var.cluster_name
   launch_mode    = "PARAVIRTUALIZED"
- 
+
   image_source_details {
     source_type = "objectStorageUri"
-    source_uri = var.openshift_image_source_uri
-     
+    source_uri  = var.openshift_image_source_uri
+
     source_image_type = "QCOW2"
   }
 }
- 
+
 resource "oci_core_shape_management" "imaging_master_shape" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   image_id       = oci_core_image.openshift_image[0].id
   shape_name     = var.master_shape
 }
- 
+
 resource "oci_core_shape_management" "imaging_worker_shape" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   image_id       = oci_core_image.openshift_image[0].id
   shape_name     = var.worker_shape
 }
- 
+
 resource "oci_core_compute_image_capability_schema" "openshift_image_capability_schema" {
   count                                               = local.create_openshift_instance_pools ? 1 : 0
   compartment_id                                      = var.compartment_ocid
@@ -229,9 +229,9 @@ resource "oci_core_compute_image_capability_schema" "openshift_image_capability_
   image_id                                            = oci_core_image.openshift_image[0].id
   schema_data                                         = local.image_schema_data
 }
- 
+
 ##Define network
-resource oci_core_vcn openshift_vcn {
+resource "oci_core_vcn" "openshift_vcn" {
   cidr_blocks = [
     var.vcn_cidr,
   ]
@@ -239,19 +239,19 @@ resource oci_core_vcn openshift_vcn {
   display_name   = var.cluster_name
   dns_label      = var.cluster_name
 }
- 
+
 resource "oci_core_internet_gateway" "internet_gateway" {
   compartment_id = var.compartment_ocid
   display_name   = "InternetGateway"
   vcn_id         = oci_core_vcn.openshift_vcn.id
 }
- 
+
 resource "oci_core_nat_gateway" "nat_gateway" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "NatGateway"
 }
- 
+
 data "oci_core_services" "oci_services" {
   filter {
     name   = "name"
@@ -259,130 +259,130 @@ data "oci_core_services" "oci_services" {
     regex  = true
   }
 }
- 
+
 resource "oci_core_service_gateway" "service_gateway" {
   #Required
   compartment_id = var.compartment_ocid
- 
+
   services {
     service_id = data.oci_core_services.oci_services.services[0]["id"]
   }
- 
+
   vcn_id = oci_core_vcn.openshift_vcn.id
- 
+
   display_name = "ServiceGateway"
 }
- 
+
 resource "oci_core_route_table" "public_routes" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "public"
- 
+
   route_rules {
-        destination       = local.anywhere
-        destination_type  = "CIDR_BLOCK"
-        network_entity_id = oci_core_internet_gateway.internet_gateway.id
+    destination       = local.anywhere
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.internet_gateway.id
   }
 }
- 
+
 resource "oci_core_route_table" "private_routes" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "private"
- 
+
   route_rules {
-        destination       = local.anywhere
-        destination_type  = "CIDR_BLOCK"
-        network_entity_id = oci_core_nat_gateway.nat_gateway.id
+    destination       = local.anywhere
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_nat_gateway.nat_gateway.id
   }
   route_rules {
-        destination       = data.oci_core_services.oci_services.services[0]["cidr_block"]
-        destination_type  = "SERVICE_CIDR_BLOCK"
-        network_entity_id = oci_core_service_gateway.service_gateway.id
+    destination       = data.oci_core_services.oci_services.services[0]["cidr_block"]
+    destination_type  = "SERVICE_CIDR_BLOCK"
+    network_entity_id = oci_core_service_gateway.service_gateway.id
   }
 }
- 
+
 resource "oci_core_security_list" "private" {
   compartment_id = var.compartment_ocid
   display_name   = "private"
   vcn_id         = oci_core_vcn.openshift_vcn.id
- 
+
   ingress_security_rules {
-        source   = var.vcn_cidr
-        protocol = local.all_protocols
+    source   = var.vcn_cidr
+    protocol = local.all_protocols
   }
   egress_security_rules {
     destination = local.anywhere
     protocol    = local.all_protocols
   }
 }
- 
+
 resource "oci_core_security_list" "public" {
   compartment_id = var.compartment_ocid
   display_name   = "public"
   vcn_id         = oci_core_vcn.openshift_vcn.id
- 
+
   ingress_security_rules {
-        source   = var.vcn_cidr
-        protocol = local.all_protocols
+    source   = var.vcn_cidr
+    protocol = local.all_protocols
   }
   ingress_security_rules {
-        source   = local.anywhere
-        protocol = "6"
-        tcp_options {
-            min = 22
-            max = 22
-        }
+    source   = local.anywhere
+    protocol = "6"
+    tcp_options {
+      min = 22
+      max = 22
+    }
   }
   egress_security_rules {
     destination = local.anywhere
     protocol    = local.all_protocols
   }
 }
- 
+
 resource "oci_core_subnet" "private" {
   cidr_block     = var.private_cidr
   display_name   = "private"
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   route_table_id = oci_core_route_table.private_routes.id
- 
+
   security_list_ids = [
     oci_core_security_list.private.id,
   ]
- 
+
   dns_label                  = "private"
   prohibit_public_ip_on_vnic = true
 }
- 
+
 resource "oci_core_subnet" "public" {
   cidr_block     = var.public_cidr
   display_name   = "public"
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   route_table_id = oci_core_route_table.public_routes.id
- 
+
   security_list_ids = [
     oci_core_security_list.public.id,
   ]
- 
+
   dns_label                  = "public"
   prohibit_public_ip_on_vnic = false
 }
- 
+
 resource "oci_core_network_security_group" "cluster_lb_nsg" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "cluster-lb-nsg"
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_1" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   direction                 = "EGRESS"
   destination               = local.anywhere
   protocol                  = local.all_protocols
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_2" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -395,7 +395,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_2"
     }
   }
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_3" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -408,7 +408,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_3"
     }
   }
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_4" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -421,7 +421,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_4"
     }
   }
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_5" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -434,7 +434,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_5"
     }
   }
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_6" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = local.all_protocols
@@ -454,27 +454,27 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_7"
     }
   }
 }
- 
+
 resource "oci_core_network_security_group" "cluster_controlplane_nsg" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "cluster-controlplane-nsg"
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_controlplane_nsg_rule_1" {
   network_security_group_id = oci_core_network_security_group.cluster_controlplane_nsg.id
   direction                 = "EGRESS"
   destination               = local.anywhere
   protocol                  = local.all_protocols
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_controlplane_nsg_2" {
   network_security_group_id = oci_core_network_security_group.cluster_controlplane_nsg.id
   protocol                  = local.all_protocols
   direction                 = "INGRESS"
   source                    = var.vcn_cidr
 }
- 
+
 # new nsg rule for api 
 resource "oci_core_network_security_group_security_rule" "cluster_controlplane_nsg_3" {
   network_security_group_id = oci_core_network_security_group.cluster_controlplane_nsg.id
@@ -488,20 +488,20 @@ resource "oci_core_network_security_group_security_rule" "cluster_controlplane_n
     }
   }
 }
- 
+
 resource "oci_core_network_security_group" "cluster_compute_nsg" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "cluster-compute-nsg"
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_compute_nsg_rule_1" {
   network_security_group_id = oci_core_network_security_group.cluster_compute_nsg.id
   direction                 = "EGRESS"
   destination               = local.anywhere
   protocol                  = local.all_protocols
 }
- 
+
 resource "oci_core_network_security_group_security_rule" "cluster_compute_nsg_2" {
   network_security_group_id = oci_core_network_security_group.cluster_compute_nsg.id
   protocol                  = local.all_protocols
@@ -510,181 +510,181 @@ resource "oci_core_network_security_group_security_rule" "cluster_compute_nsg_2"
 }
 
 resource "oci_load_balancer_load_balancer" "openshift_internal_lb" {
-  compartment_id = var.compartment_ocid
-  display_name = "${var.cluster_name}-openshift_internal_lb"
-  shape = "flexible"
-  subnet_ids = [oci_core_subnet.private.id]
+  compartment_id             = var.compartment_ocid
+  display_name               = "${var.cluster_name}-openshift_internal_lb"
+  shape                      = "flexible"
+  subnet_ids                 = [oci_core_subnet.private.id]
   is_private                 = true
   network_security_group_ids = [oci_core_network_security_group.cluster_lb_nsg.id]
 
   shape_details {
-      maximum_bandwidth_in_mbps = var.load_balancer_shape_details_maximum_bandwidth_in_mbps
-      minimum_bandwidth_in_mbps = var.load_balancer_shape_details_minimum_bandwidth_in_mbps
+    maximum_bandwidth_in_mbps = var.load_balancer_shape_details_maximum_bandwidth_in_mbps
+    minimum_bandwidth_in_mbps = var.load_balancer_shape_details_minimum_bandwidth_in_mbps
   }
 }
 
 resource "oci_load_balancer_load_balancer" "openshift_external_lb" {
-  compartment_id = var.compartment_ocid
-  display_name = "${var.cluster_name}-openshift_external_lb"
-  shape = "flexible"
-  subnet_ids = [oci_core_subnet.public.id]
+  compartment_id             = var.compartment_ocid
+  display_name               = "${var.cluster_name}-openshift_external_lb"
+  shape                      = "flexible"
+  subnet_ids                 = [oci_core_subnet.public.id]
   is_private                 = false
   network_security_group_ids = [oci_core_network_security_group.cluster_lb_nsg.id]
 
   shape_details {
-      maximum_bandwidth_in_mbps = var.load_balancer_shape_details_maximum_bandwidth_in_mbps
-      minimum_bandwidth_in_mbps = var.load_balancer_shape_details_minimum_bandwidth_in_mbps
+    maximum_bandwidth_in_mbps = var.load_balancer_shape_details_maximum_bandwidth_in_mbps
+    minimum_bandwidth_in_mbps = var.load_balancer_shape_details_minimum_bandwidth_in_mbps
   }
 }
- 
+
 locals {
   lb_private_addr = element([
-    for address in oci_load_balancer_load_balancer.openshift_internal_lb.ip_address_details :address
+    for address in oci_load_balancer_load_balancer.openshift_internal_lb.ip_address_details : address
     if address.is_public == false
-], 0).ip_address
+  ], 0).ip_address
   lb_public_addr = element([
-    for address in oci_load_balancer_load_balancer.openshift_external_lb.ip_address_details :address
+    for address in oci_load_balancer_load_balancer.openshift_external_lb.ip_address_details : address
     if address.is_public == true
   ], 0).ip_address
 }
- 
+
 resource "oci_load_balancer_backend_set" "openshift_cluster_api_backend_external" {
-    health_checker {
-        protocol    = "HTTP"
-        port        = 6080
-        return_code = 200
-        url_path    = "/readyz"
-        interval_ms = 10000
-        timeout_in_millis  = 3000
-        retries            = 3
-    }
-    name                     = "openshift_cluster_api_backend"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
-    policy                   = "LEAST_CONNECTIONS"
-    depends_on               = [oci_load_balancer_load_balancer.openshift_external_lb]
+  health_checker {
+    protocol          = "HTTP"
+    port              = 6080
+    return_code       = 200
+    url_path          = "/readyz"
+    interval_ms       = 10000
+    timeout_in_millis = 3000
+    retries           = 3
+  }
+  name             = "openshift_cluster_api_backend"
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id
+  policy           = "LEAST_CONNECTIONS"
+  depends_on       = [oci_load_balancer_load_balancer.openshift_external_lb]
 }
- 
+
 resource "oci_load_balancer_listener" "openshift_cluster_api_listener_external" {
-    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_external.name
-    name                     = "openshift_cluster_api_listener"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
-    port                     = 6443
-    protocol                 = "TCP"
-    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_api_backend_external]
+  default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_external.name
+  name                     = "openshift_cluster_api_listener"
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
+  port                     = 6443
+  protocol                 = "TCP"
+  depends_on               = [oci_load_balancer_backend_set.openshift_cluster_api_backend_external]
 }
- 
+
 resource "oci_load_balancer_backend_set" "openshift_cluster_ingress_http_backend" {
-    health_checker {
-        protocol = "TCP"
-        port     = 80
-        interval_ms = 10000
-        timeout_in_millis  = 3000
-        retries            = 3
-    }
-    name                     = "openshift_cluster_ingress_http"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
-    policy                   = "LEAST_CONNECTIONS"
-    depends_on               = [oci_load_balancer_load_balancer.openshift_external_lb]
+  health_checker {
+    protocol          = "TCP"
+    port              = 80
+    interval_ms       = 10000
+    timeout_in_millis = 3000
+    retries           = 3
+  }
+  name             = "openshift_cluster_ingress_http"
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id
+  policy           = "LEAST_CONNECTIONS"
+  depends_on       = [oci_load_balancer_load_balancer.openshift_external_lb]
 }
- 
+
 resource "oci_load_balancer_listener" "openshift_cluster_ingress_http" {
-    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend.name
-    name                     = "openshift_cluster_ingress_http"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
-    port                     = 80
-    protocol                 = "TCP"
-    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend]
+  default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend.name
+  name                     = "openshift_cluster_ingress_http"
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
+  port                     = 80
+  protocol                 = "TCP"
+  depends_on               = [oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend]
 }
- 
+
 resource "oci_load_balancer_backend_set" "openshift_cluster_ingress_https_backend" {
-    health_checker {
-        protocol = "TCP"
-        port     = 443
-        interval_ms = 10000
-        timeout_in_millis  = 3000
-        retries            = 3
-    }
-    name                     = "openshift_cluster_ingress_https"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
-    policy                   = "LEAST_CONNECTIONS"
-    depends_on               = [oci_load_balancer_load_balancer.openshift_external_lb]
+  health_checker {
+    protocol          = "TCP"
+    port              = 443
+    interval_ms       = 10000
+    timeout_in_millis = 3000
+    retries           = 3
+  }
+  name             = "openshift_cluster_ingress_https"
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id
+  policy           = "LEAST_CONNECTIONS"
+  depends_on       = [oci_load_balancer_load_balancer.openshift_external_lb]
 }
- 
+
 resource "oci_load_balancer_listener" "openshift_cluster_ingress_https" {
-    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
-    name                     = "openshift_cluster_ingress_https"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
-    port                     = 443
-    protocol                 = "TCP"
-    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend]
+  default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
+  name                     = "openshift_cluster_ingress_https"
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
+  port                     = 443
+  protocol                 = "TCP"
+  depends_on               = [oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend]
 }
 
 resource "oci_load_balancer_backend_set" "openshift_cluster_api_backend_internal" {
-    health_checker {
-        protocol    = "HTTP"
-        port        = 6080
-        return_code = 200
-        url_path    = "/readyz"
-        interval_ms = 10000
-        timeout_in_millis  = 3000
-        retries            = 3
-    }
-    name                     = "openshift_cluster_api_backend"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
-    policy                   = "LEAST_CONNECTIONS"
-    depends_on               = [oci_load_balancer_load_balancer.openshift_internal_lb]
+  health_checker {
+    protocol          = "HTTP"
+    port              = 6080
+    return_code       = 200
+    url_path          = "/readyz"
+    interval_ms       = 10000
+    timeout_in_millis = 3000
+    retries           = 3
+  }
+  name             = "openshift_cluster_api_backend"
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_internal_lb.id
+  policy           = "LEAST_CONNECTIONS"
+  depends_on       = [oci_load_balancer_load_balancer.openshift_internal_lb]
 }
- 
+
 resource "oci_load_balancer_listener" "openshift_cluster_api_listener_internal" {
-    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_internal.name
-    name                     = "openshift_cluster_api_listener"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
-    port                     = 6443
-    protocol                 = "TCP"
-    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_api_backend_internal]
+  default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_internal.name
+  name                     = "openshift_cluster_api_listener"
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
+  port                     = 6443
+  protocol                 = "TCP"
+  depends_on               = [oci_load_balancer_backend_set.openshift_cluster_api_backend_internal]
 }
 
 resource "oci_load_balancer_backend_set" "openshift_cluster_infra-mcs_backend" {
-    health_checker {
-        protocol    = "HTTP"
-        port        = 22624
-        return_code = 200
-        url_path    = "/healthz"
-        interval_ms = 10000
-        timeout_in_millis  = 3000
-        retries            = 3
-    }
-    name                     = "openshift_cluster_infra-mcs"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
-    policy                   = "LEAST_CONNECTIONS"
-    depends_on               = [oci_load_balancer_load_balancer.openshift_internal_lb]
+  health_checker {
+    protocol          = "HTTP"
+    port              = 22624
+    return_code       = 200
+    url_path          = "/healthz"
+    interval_ms       = 10000
+    timeout_in_millis = 3000
+    retries           = 3
+  }
+  name             = "openshift_cluster_infra-mcs"
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_internal_lb.id
+  policy           = "LEAST_CONNECTIONS"
+  depends_on       = [oci_load_balancer_load_balancer.openshift_internal_lb]
 }
- 
+
 resource "oci_load_balancer_listener" "openshift_cluster_infra-mcs" {
-    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend.name
-    name                     = "openshift_cluster_infra-mcs"
-    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
-    port                     = 22623
-    protocol                 = "TCP"
-    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend]
+  default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend.name
+  name                     = "openshift_cluster_infra-mcs"
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
+  port                     = 22623
+  protocol                 = "TCP"
+  depends_on               = [oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend]
 }
 
 resource "oci_load_balancer_backend_set" "openshift_cluster_infra-mcs_backend_2" {
   health_checker {
-        protocol    = "HTTP"
-        port        = 22624
-        return_code = 200
-        url_path    = "/healthz"
-        interval_ms = 10000
-        timeout_in_millis  = 3000
-        retries            = 3
-    }
-  name                     = "openshift_cluster_infra-mcs_2"
-  load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
-  policy                   = "LEAST_CONNECTIONS"
-  depends_on               = [oci_load_balancer_load_balancer.openshift_internal_lb]
+    protocol          = "HTTP"
+    port              = 22624
+    return_code       = 200
+    url_path          = "/healthz"
+    interval_ms       = 10000
+    timeout_in_millis = 3000
+    retries           = 3
+  }
+  name             = "openshift_cluster_infra-mcs_2"
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_internal_lb.id
+  policy           = "LEAST_CONNECTIONS"
+  depends_on       = [oci_load_balancer_load_balancer.openshift_internal_lb]
 }
- 
+
 resource "oci_load_balancer_listener" "openshift_cluster_infra-mcs_2" {
   default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2.name
   name                     = "openshift_cluster_infra-mcs_2"
@@ -693,29 +693,29 @@ resource "oci_load_balancer_listener" "openshift_cluster_infra-mcs_2" {
   protocol                 = "TCP"
   depends_on               = [oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2]
 }
- 
+
 resource "oci_identity_dynamic_group" "openshift_master_nodes" {
-    compartment_id = var.tenancy_ocid
-    description    = "OpenShift master nodes"
-    matching_rule  = "all {instance.compartment.id='${var.compartment_ocid}', tag.openshift-${var.cluster_name}.instance-role.value='master'}"
-    name           = "${var.cluster_name}_master_nodes"
-    provider       = oci.home
+  compartment_id = var.tenancy_ocid
+  description    = "OpenShift master nodes"
+  matching_rule  = "all {instance.compartment.id='${var.compartment_ocid}', tag.openshift-${var.cluster_name}.instance-role.value='master'}"
+  name           = "${var.cluster_name}_master_nodes"
+  provider       = oci.home
 }
- 
+
 resource "oci_identity_policy" "openshift_master_nodes" {
-    compartment_id = var.compartment_ocid
-    description    = "OpenShift master nodes instance principal"
-    name           = "${var.cluster_name}_master_nodes"
-    statements     = [
-        "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage volume-family in compartment id ${var.compartment_ocid}",
-        "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage instance-family in compartment id ${var.compartment_ocid}",
-        "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage security-lists in compartment id ${var.compartment_ocid}",
-        "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to use virtual-network-family in compartment id ${var.compartment_ocid}",
-        "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage load-balancers in compartment id ${var.compartment_ocid}",
-    ]
-    provider       = oci.home
+  compartment_id = var.compartment_ocid
+  description    = "OpenShift master nodes instance principal"
+  name           = "${var.cluster_name}_master_nodes"
+  statements = [
+    "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage volume-family in compartment id ${var.compartment_ocid}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage instance-family in compartment id ${var.compartment_ocid}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage security-lists in compartment id ${var.compartment_ocid}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to use virtual-network-family in compartment id ${var.compartment_ocid}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.openshift_master_nodes.name} to manage load-balancers in compartment id ${var.compartment_ocid}",
+  ]
+  provider = oci.home
 }
- 
+
 resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
   compartment_id = var.tenancy_ocid
   description    = "OpenShift worker nodes"
@@ -723,8 +723,8 @@ resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
   name           = "${var.cluster_name}_worker_nodes"
   provider       = oci.home
 }
- 
-resource oci_dns_zone openshift {
+
+resource "oci_dns_zone" "openshift" {
   compartment_id = var.compartment_ocid
   name           = var.zone_dns
   scope          = var.enable_private_dns ? "PRIVATE" : null
@@ -732,8 +732,8 @@ resource oci_dns_zone openshift {
   zone_type      = "PRIMARY"
   depends_on     = [oci_core_subnet.private]
 }
- 
-resource oci_dns_rrset openshift_api {
+
+resource "oci_dns_rrset" "openshift_api" {
   domain = "api.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "api.${var.cluster_name}.${var.zone_dns}"
@@ -744,8 +744,8 @@ resource oci_dns_rrset openshift_api {
   rtype           = "A"
   zone_name_or_id = oci_dns_zone.openshift.id
 }
- 
-resource oci_dns_rrset openshift_apps {
+
+resource "oci_dns_rrset" "openshift_apps" {
   domain = "*.apps.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "*.apps.${var.cluster_name}.${var.zone_dns}"
@@ -756,8 +756,8 @@ resource oci_dns_rrset openshift_apps {
   rtype           = "A"
   zone_name_or_id = oci_dns_zone.openshift.id
 }
- 
-resource oci_dns_rrset openshift_api_int {
+
+resource "oci_dns_rrset" "openshift_api_int" {
   domain = "api-int.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "api-int.${var.cluster_name}.${var.zone_dns}"
@@ -768,17 +768,17 @@ resource oci_dns_rrset openshift_api_int {
   rtype           = "A"
   zone_name_or_id = oci_dns_zone.openshift.id
 }
- 
+
 resource "time_sleep" "wait_180_seconds" {
-  depends_on = [oci_core_vcn.openshift_vcn]
+  depends_on      = [oci_core_vcn.openshift_vcn]
   create_duration = "180s"
 }
- 
+
 data "oci_core_vcn_dns_resolver_association" "dns_resolver_association" {
   vcn_id     = oci_core_vcn.openshift_vcn.id
   depends_on = [time_sleep.wait_180_seconds]
 }
- 
+
 data "oci_dns_resolver" "dns_resolver" {
   depends_on = [
     data.oci_core_vcn_dns_resolver_association.dns_resolver_association
@@ -786,8 +786,8 @@ data "oci_dns_resolver" "dns_resolver" {
   resolver_id = data.oci_core_vcn_dns_resolver_association.dns_resolver_association.dns_resolver_id
   scope       = "PRIVATE"
 }
- 
-resource oci_core_instance_configuration master_node_config {
+
+resource "oci_core_instance_configuration" "master_node_config" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   display_name   = "${var.cluster_name}-master"
@@ -799,7 +799,7 @@ resource oci_core_instance_configuration master_node_config {
       create_vnic_details {
         assign_private_dns_record = "true"
         assign_public_ip          = "false"
-        nsg_ids                   = [
+        nsg_ids = [
           oci_core_network_security_group.cluster_controlplane_nsg.id,
         ]
         subnet_id = oci_core_subnet.private.id
@@ -821,8 +821,8 @@ resource oci_core_instance_configuration master_node_config {
     }
   }
 }
- 
-resource oci_core_instance_pool master_nodes {
+
+resource "oci_core_instance_pool" "master_nodes" {
   count                     = local.create_openshift_instance_pools ? 1 : 0
   compartment_id            = var.compartment_ocid
   display_name              = "${var.cluster_name}-master"
@@ -855,7 +855,7 @@ resource oci_core_instance_pool master_nodes {
     availability_domain = data.oci_identity_availability_domain.availability_domain.name
     primary_subnet_id   = oci_core_subnet.private.id
   }
-  size       = var.master_count
+  size = var.master_count
   depends_on = [
     oci_load_balancer_backend_set.openshift_cluster_api_backend_external,
     oci_load_balancer_backend_set.openshift_cluster_api_backend_internal,
@@ -864,8 +864,8 @@ resource oci_core_instance_pool master_nodes {
     oci_core_instance_configuration.master_node_config,
   ]
 }
- 
-resource oci_core_instance_configuration worker_node_config {
+
+resource "oci_core_instance_configuration" "worker_node_config" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   display_name   = "${var.cluster_name}-worker"
@@ -877,7 +877,7 @@ resource oci_core_instance_configuration worker_node_config {
       create_vnic_details {
         assign_private_dns_record = "true"
         assign_public_ip          = "false"
-        nsg_ids                   = [
+        nsg_ids = [
           oci_core_network_security_group.cluster_compute_nsg.id,
         ]
         subnet_id = oci_core_subnet.private.id
@@ -899,8 +899,8 @@ resource oci_core_instance_configuration worker_node_config {
     }
   }
 }
- 
-resource oci_core_instance_pool worker_nodes {
+
+resource "oci_core_instance_pool" "worker_nodes" {
   count                     = local.create_openshift_instance_pools ? 1 : 0
   compartment_id            = var.compartment_ocid
   display_name              = "${var.cluster_name}-worker"
@@ -921,22 +921,22 @@ resource oci_core_instance_pool worker_nodes {
     availability_domain = data.oci_identity_availability_domain.availability_domain.name
     primary_subnet_id   = oci_core_subnet.private.id
   }
-  size       = var.worker_count
+  size = var.worker_count
   depends_on = [
     oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend,
     oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend,
     oci_core_instance_configuration.worker_node_config,
   ]
 }
- 
+
 output "open_shift_lb_private_addr" {
   value = local.lb_private_addr
 }
- 
+
 output "open_shift_lb_public_addr" {
   value = local.lb_public_addr
 }
- 
+
 output "oci_ccm_config" {
   value = <<OCICCMCONFIG
 useInstancePrincipals: true

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -1,6 +1,6 @@
 ## Infra Region or Default Region of the Current RMS Stack
 variable "region" {}
-
+ 
 variable zone_dns {
     type        = string
     description = "The name of cluster's DNS zone. This name must be the same as what was specified during OpenShift ISO creation."
@@ -11,7 +11,7 @@ variable master_count {
     description = "The number of master nodes in the cluster. The default value is 3. "
 }
 variable master_shape {
-    default     = "VM.Standard.E4.Flex" 
+    default     = "VM.Standard.E4.Flex"
     description = "Compute shape of the master nodes. The default shape is VM.Standard.E4.Flex. For more detail regarding compute shapes, please visit https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm ."
 }
 variable master_ocpu {
@@ -25,22 +25,22 @@ variable master_memory {
     description = "The amount of memory available for the shape of each master node, in gigabytes. The default value is 16. "
 }
 variable master_boot_size {
-    default     = 500
+    default     = 1024
     type        = number
-    description = "The size of the boot volume of each master node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 500 GB. "
+    description = "The size of the boot volume of each master node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 1024 GB. "
 }
 variable master_boot_volume_vpus_per_gb {
-    default     = 60
+    default     = 90
     type        = number
     description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each master node. The default value is 60. "
 }
 variable worker_count {
-    default     = 3
+    default     = 4
     type        = number
     description = "The number of worker nodes in the cluster. The default value is 3. "
 }
 variable worker_shape {
-    default     = "VM.Standard.E4.Flex" 
+    default     = "VM.Standard.E4.Flex"
     description = "Compute shape of the worker nodes. The default shape is VM.Standard.E4.Flex. For more detail regarding compute shapes, please visit https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm "
 }
 variable worker_ocpu {
@@ -49,7 +49,7 @@ variable worker_ocpu {
     description = "The number of OCPUs available for the shape of each worker node. The default value is 4. "
 }
 variable worker_boot_volume_vpus_per_gb {
-    default     = 20
+    default     = 30
     type        = number
     description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each worker node. The default value is 20. "
 }
@@ -62,26 +62,34 @@ variable worker_boot_size {
     default     = 100
     type        = number
     description = "The size of the boot volume of each worker node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 100 GB."
-
 }
-
+variable load_balancer_shape_details_maximum_bandwidth_in_mbps {
+  default = 500
+  type = number
+  description = "Bandwidth in Mbps that determines the maximum bandwidth (ingress plus egress) that the load balancer can achieve. The values must be between minimumBandwidthInMbps and 8000"
+}
+variable load_balancer_shape_details_minimum_bandwidth_in_mbps {
+  default = 10
+  type = number
+  description = " Bandwidth in Mbps that determines the total pre-provisioned bandwidth (ingress plus egress). The values must be between 10 and the maximumBandwidthInMbps"
+}
 variable "tenancy_ocid" {
     type        = string
     description = "The ocid of the current tenancy."
 }
-
+ 
 ## Openshift infrastructure compartment
 variable compartment_ocid {
     type        = string
     description = "The ocid of the compartment where you wish to create the OpenShift cluster."
 }
-
+ 
 ## Openshift cluster name
 variable cluster_name {
     type        = string
     description = "The name of your OpenShift cluster. It should be the same as what was specified when creating the OpenShift ISO and it should be DNS compatible."
 }
-
+ 
 variable "vcn_cidr" {
   default = "10.0.0.0/16"
   description = "The IPv4 CIDR blocks for the VCN of your OpenShift Cluster. The default value is 10.0.0.0/16. "
@@ -94,27 +102,27 @@ variable "public_cidr" {
   default = "10.0.0.0/20"
   description = "The IPv4 CIDR blocks for the public subnet of your OpenShift Cluster. The default value is 10.0.0.0/20. "
 }
-
+ 
 variable "openshift_image_source_uri" {
   type        = string
   description = "The OCI Object Storage URL for the OpenShift image. Before provisioning resources through this Resource Manager stack, users should upload the OpenShift image to OCI Object Storage, create a pre-authenticated requests (PAR) uri, and paste the uri to this block. For more detail regarding Object storage and PAR, please visit https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm and https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingpreauthenticatedrequests.htm ."
 }
-
+ 
 variable "enable_private_dns" {
   type        = bool
   description = "If the switch is enabled, a private DNS zone will be created, and users should edit the /etc/hosts file for resolution. Otherwise, a public DNS zone will be created based on the given domain."
   default     = false
 }
-
+ 
 # Reginal Infrastructure Terraform Provider
 provider oci {
-	region = var.region
+    region = var.region
 }
-
+ 
 data "oci_identity_tenancy" "tenancy" {
   tenancy_id = var.tenancy_ocid
 }
-
+ 
 data oci_identity_region_subscriptions region_subscriptions {
   tenancy_id = var.tenancy_ocid
   filter {
@@ -123,34 +131,34 @@ data oci_identity_region_subscriptions region_subscriptions {
   }
 }
 data oci_identity_regions regions {}
-
-
+ 
+ 
 locals {
   region_map = {
     for r in data.oci_identity_regions.regions.regions :
     r.key => r.name
   }
-
+ 
   home_region = lookup(local.region_map, data.oci_identity_tenancy.tenancy.home_region_key)
 }
-
-# Home Region Terraform Provider 
+ 
+# Home Region Terraform Provider
 provider oci {
-	alias  = "home"
+    alias  = "home"
   region = local.home_region
 }
-
+ 
 locals {
   all_protocols = "all"
   anywhere      = "0.0.0.0/0"
   create_openshift_instance_pools = true
 }
-
+ 
 data oci_identity_availability_domain availability_domain {
   compartment_id = var.compartment_ocid
   ad_number      = "1"
 }
-
+ 
 ##Defined tag namespace. Use to mark instance roles and configure instance policy
 resource oci_identity_tag_namespace openshift_tags {
   compartment_id = var.compartment_ocid
@@ -159,7 +167,7 @@ resource oci_identity_tag_namespace openshift_tags {
   name           = "openshift-${var.cluster_name}"
   provider       = oci.home
 }
-
+ 
 resource oci_identity_tag openshift_instance_role {
   description      = "Describe instance role inside OpenShift cluster"
   is_cost_tracking = "false"
@@ -175,45 +183,45 @@ resource oci_identity_tag openshift_instance_role {
   }
   provider         = oci.home
 }
-
+ 
 data "oci_core_compute_global_image_capability_schemas" "image_capability_schemas" {
 }
-
+ 
 locals {
   global_image_capability_schemas = data.oci_core_compute_global_image_capability_schemas.image_capability_schemas.compute_global_image_capability_schemas
   image_schema_data               = {
-    "Compute.Firmware" = "{\"values\": [\"BIOS\",\"UEFI_64\"],\"defaultValue\": \"UEFI_64\",\"descriptorType\": \"enumstring\",\"source\": \"IMAGE\"}"
+    "Compute.Firmware" = "{\"values\": [\"UEFI_64\"],\"defaultValue\": \"UEFI_64\",\"descriptorType\": \"enumstring\",\"source\": \"IMAGE\"}"
   }
 }
-
+ 
 resource "oci_core_image" "openshift_image" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   display_name   = var.cluster_name
   launch_mode    = "PARAVIRTUALIZED"
-
+ 
   image_source_details {
     source_type = "objectStorageUri"
     source_uri = var.openshift_image_source_uri
-    
+     
     source_image_type = "QCOW2"
   }
 }
-
+ 
 resource "oci_core_shape_management" "imaging_master_shape" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   image_id       = oci_core_image.openshift_image[0].id
   shape_name     = var.master_shape
 }
-
+ 
 resource "oci_core_shape_management" "imaging_worker_shape" {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
   image_id       = oci_core_image.openshift_image[0].id
   shape_name     = var.worker_shape
 }
-
+ 
 resource "oci_core_compute_image_capability_schema" "openshift_image_capability_schema" {
   count                                               = local.create_openshift_instance_pools ? 1 : 0
   compartment_id                                      = var.compartment_ocid
@@ -221,7 +229,7 @@ resource "oci_core_compute_image_capability_schema" "openshift_image_capability_
   image_id                                            = oci_core_image.openshift_image[0].id
   schema_data                                         = local.image_schema_data
 }
-
+ 
 ##Define network
 resource oci_core_vcn openshift_vcn {
   cidr_blocks = [
@@ -231,19 +239,19 @@ resource oci_core_vcn openshift_vcn {
   display_name   = var.cluster_name
   dns_label      = var.cluster_name
 }
-
+ 
 resource "oci_core_internet_gateway" "internet_gateway" {
   compartment_id = var.compartment_ocid
   display_name   = "InternetGateway"
   vcn_id         = oci_core_vcn.openshift_vcn.id
 }
-
+ 
 resource "oci_core_nat_gateway" "nat_gateway" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "NatGateway"
 }
-
+ 
 data "oci_core_services" "oci_services" {
   filter {
     name   = "name"
@@ -251,37 +259,37 @@ data "oci_core_services" "oci_services" {
     regex  = true
   }
 }
-
+ 
 resource "oci_core_service_gateway" "service_gateway" {
   #Required
   compartment_id = var.compartment_ocid
-
+ 
   services {
     service_id = data.oci_core_services.oci_services.services[0]["id"]
   }
-
+ 
   vcn_id = oci_core_vcn.openshift_vcn.id
-
+ 
   display_name = "ServiceGateway"
 }
-
+ 
 resource "oci_core_route_table" "public_routes" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "public"
-
+ 
   route_rules {
         destination       = local.anywhere
         destination_type  = "CIDR_BLOCK"
         network_entity_id = oci_core_internet_gateway.internet_gateway.id
   }
 }
-
+ 
 resource "oci_core_route_table" "private_routes" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "private"
-
+ 
   route_rules {
         destination       = local.anywhere
         destination_type  = "CIDR_BLOCK"
@@ -293,12 +301,12 @@ resource "oci_core_route_table" "private_routes" {
         network_entity_id = oci_core_service_gateway.service_gateway.id
   }
 }
-
+ 
 resource "oci_core_security_list" "private" {
   compartment_id = var.compartment_ocid
   display_name   = "private"
   vcn_id         = oci_core_vcn.openshift_vcn.id
-
+ 
   ingress_security_rules {
         source   = var.vcn_cidr
         protocol = local.all_protocols
@@ -308,12 +316,12 @@ resource "oci_core_security_list" "private" {
     protocol    = local.all_protocols
   }
 }
-
+ 
 resource "oci_core_security_list" "public" {
   compartment_id = var.compartment_ocid
   display_name   = "public"
   vcn_id         = oci_core_vcn.openshift_vcn.id
-
+ 
   ingress_security_rules {
         source   = var.vcn_cidr
         protocol = local.all_protocols
@@ -331,50 +339,50 @@ resource "oci_core_security_list" "public" {
     protocol    = local.all_protocols
   }
 }
-
+ 
 resource "oci_core_subnet" "private" {
   cidr_block     = var.private_cidr
   display_name   = "private"
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   route_table_id = oci_core_route_table.private_routes.id
-
+ 
   security_list_ids = [
     oci_core_security_list.private.id,
   ]
-
+ 
   dns_label                  = "private"
   prohibit_public_ip_on_vnic = true
 }
-
+ 
 resource "oci_core_subnet" "public" {
   cidr_block     = var.public_cidr
   display_name   = "public"
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   route_table_id = oci_core_route_table.public_routes.id
-
+ 
   security_list_ids = [
     oci_core_security_list.public.id,
   ]
-
+ 
   dns_label                  = "public"
   prohibit_public_ip_on_vnic = false
 }
-
+ 
 resource "oci_core_network_security_group" "cluster_lb_nsg" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "cluster-lb-nsg"
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_1" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   direction                 = "EGRESS"
   destination               = local.anywhere
   protocol                  = local.all_protocols
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_2" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -387,7 +395,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_2"
     }
   }
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_3" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -400,7 +408,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_3"
     }
   }
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_4" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -413,7 +421,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_4"
     }
   }
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_5" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
@@ -426,7 +434,7 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_5"
     }
   }
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_6" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = local.all_protocols
@@ -434,39 +442,66 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_6"
   source                    = var.vcn_cidr
 }
 
+resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_7" {
+  network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
+  protocol                  = "6"
+  direction                 = "INGRESS"
+  source                    = local.anywhere
+  tcp_options {
+    destination_port_range {
+      min = 22624
+      max = 22624
+    }
+  }
+}
+ 
 resource "oci_core_network_security_group" "cluster_controlplane_nsg" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "cluster-controlplane-nsg"
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_controlplane_nsg_rule_1" {
   network_security_group_id = oci_core_network_security_group.cluster_controlplane_nsg.id
   direction                 = "EGRESS"
   destination               = local.anywhere
   protocol                  = local.all_protocols
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_controlplane_nsg_2" {
   network_security_group_id = oci_core_network_security_group.cluster_controlplane_nsg.id
   protocol                  = local.all_protocols
   direction                 = "INGRESS"
   source                    = var.vcn_cidr
 }
-
+ 
+# new nsg rule for api 
+resource "oci_core_network_security_group_security_rule" "cluster_controlplane_nsg_3" {
+  network_security_group_id = oci_core_network_security_group.cluster_controlplane_nsg.id
+  protocol                  = "6"
+  direction                 = "INGRESS"
+  source                    = local.anywhere
+  tcp_options {
+    destination_port_range {
+      min = 6443
+      max = 6443
+    }
+  }
+}
+ 
 resource "oci_core_network_security_group" "cluster_compute_nsg" {
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.openshift_vcn.id
   display_name   = "cluster-compute-nsg"
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_compute_nsg_rule_1" {
   network_security_group_id = oci_core_network_security_group.cluster_compute_nsg.id
   direction                 = "EGRESS"
   destination               = local.anywhere
   protocol                  = local.all_protocols
 }
-
+ 
 resource "oci_core_network_security_group_security_rule" "cluster_compute_nsg_2" {
   network_security_group_id = oci_core_network_security_group.cluster_compute_nsg.id
   protocol                  = local.all_protocols
@@ -474,123 +509,201 @@ resource "oci_core_network_security_group_security_rule" "cluster_compute_nsg_2"
   source                    = var.vcn_cidr
 }
 
-resource "oci_network_load_balancer_network_load_balancer" "openshift_lb" {
-  compartment_id             = var.compartment_ocid
-  subnet_id                  = oci_core_subnet.public.id
-  display_name               = "openshift_lb"
-  is_private                 = false
+resource "oci_load_balancer_load_balancer" "openshift_internal_lb" {
+  compartment_id = var.compartment_ocid
+  display_name = "${var.cluster_name}-openshift_internal_lb"
+  shape = "flexible"
+  subnet_ids = [oci_core_subnet.private.id]
+  is_private                 = true
   network_security_group_ids = [oci_core_network_security_group.cluster_lb_nsg.id]
+
+  shape_details {
+      maximum_bandwidth_in_mbps = var.load_balancer_shape_details_maximum_bandwidth_in_mbps
+      minimum_bandwidth_in_mbps = var.load_balancer_shape_details_minimum_bandwidth_in_mbps
+  }
 }
 
+resource "oci_load_balancer_load_balancer" "openshift_external_lb" {
+  compartment_id = var.compartment_ocid
+  display_name = "${var.cluster_name}-openshift_external_lb"
+  shape = "flexible"
+  subnet_ids = [oci_core_subnet.public.id]
+  is_private                 = false
+  network_security_group_ids = [oci_core_network_security_group.cluster_lb_nsg.id]
+
+  shape_details {
+      maximum_bandwidth_in_mbps = var.load_balancer_shape_details_maximum_bandwidth_in_mbps
+      minimum_bandwidth_in_mbps = var.load_balancer_shape_details_minimum_bandwidth_in_mbps
+  }
+}
+ 
 locals {
   lb_private_addr = element([
-    for address in oci_network_load_balancer_network_load_balancer.openshift_lb.ip_addresses :address 
+    for address in oci_load_balancer_load_balancer.openshift_internal_lb.ip_address_details :address
     if address.is_public == false
 ], 0).ip_address
   lb_public_addr = element([
-    for address in oci_network_load_balancer_network_load_balancer.openshift_lb.ip_addresses :address
+    for address in oci_load_balancer_load_balancer.openshift_external_lb.ip_address_details :address
     if address.is_public == true
   ], 0).ip_address
 }
-
-resource "oci_network_load_balancer_backend_set" "openshift_cluster_api_backend" {
+ 
+resource "oci_load_balancer_backend_set" "openshift_cluster_api_backend_external" {
     health_checker {
-        protocol    = "HTTPS"
-        port        = 6443
+        protocol    = "HTTP"
+        port        = 6080
         return_code = 200
         url_path    = "/readyz"
+        interval_ms = 10000
+        timeout_in_millis  = 3000
+        retries            = 3
     }
     name                     = "openshift_cluster_api_backend"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
-    policy                   = "FIVE_TUPLE"
-    is_preserve_source       = false
-    depends_on               = [oci_network_load_balancer_network_load_balancer.openshift_lb]
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
+    policy                   = "LEAST_CONNECTIONS"
+    depends_on               = [oci_load_balancer_load_balancer.openshift_external_lb]
 }
-
-resource "oci_network_load_balancer_listener" "openshift_cluster_api" {
-    default_backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_api_backend.name
-    name                     = "openshift_cluster_api"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+ 
+resource "oci_load_balancer_listener" "openshift_cluster_api_listener_external" {
+    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_external.name
+    name                     = "openshift_cluster_api_listener"
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
     port                     = 6443
     protocol                 = "TCP"
-    depends_on               = [oci_network_load_balancer_backend_set.openshift_cluster_api_backend]
+    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_api_backend_external]
 }
-
-resource "oci_network_load_balancer_backend_set" "openshift_cluster_ingress_http_backend" {
+ 
+resource "oci_load_balancer_backend_set" "openshift_cluster_ingress_http_backend" {
     health_checker {
         protocol = "TCP"
         port     = 80
+        interval_ms = 10000
+        timeout_in_millis  = 3000
+        retries            = 3
     }
-    name                     = "openshift_cluster_ingress_http_backend"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
-    policy                   = "FIVE_TUPLE"
-    is_preserve_source       = false
-    depends_on               = [oci_network_load_balancer_listener.openshift_cluster_api]
-}
-
-resource "oci_network_load_balancer_listener" "openshift_cluster_ingress_http" {
-    default_backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_ingress_http_backend.name
     name                     = "openshift_cluster_ingress_http"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
+    policy                   = "LEAST_CONNECTIONS"
+    depends_on               = [oci_load_balancer_load_balancer.openshift_external_lb]
+}
+ 
+resource "oci_load_balancer_listener" "openshift_cluster_ingress_http" {
+    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend.name
+    name                     = "openshift_cluster_ingress_http"
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
     port                     = 80
     protocol                 = "TCP"
-    depends_on               = [oci_network_load_balancer_backend_set.openshift_cluster_ingress_http_backend]
+    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend]
 }
-
-resource "oci_network_load_balancer_backend_set" "openshift_cluster_ingress_https_backend" {
+ 
+resource "oci_load_balancer_backend_set" "openshift_cluster_ingress_https_backend" {
     health_checker {
         protocol = "TCP"
         port     = 443
+        interval_ms = 10000
+        timeout_in_millis  = 3000
+        retries            = 3
     }
-    name                     = "openshift_cluster_ingress_https_backend"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
-    policy                   = "FIVE_TUPLE"
-    is_preserve_source       = false
-    depends_on               = [oci_network_load_balancer_listener.openshift_cluster_ingress_http]
-}
-
-resource "oci_network_load_balancer_listener" "openshift_cluster_ingress_https" {
-    default_backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
     name                     = "openshift_cluster_ingress_https"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
+    policy                   = "LEAST_CONNECTIONS"
+    depends_on               = [oci_load_balancer_load_balancer.openshift_external_lb]
+}
+ 
+resource "oci_load_balancer_listener" "openshift_cluster_ingress_https" {
+    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
+    name                     = "openshift_cluster_ingress_https"
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_external_lb.id
     port                     = 443
     protocol                 = "TCP"
-    depends_on               = [oci_network_load_balancer_backend_set.openshift_cluster_ingress_https_backend]
+    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend]
 }
 
-resource "oci_network_load_balancer_backend_set" "openshift_cluster_infra-mcs_backend" {
+resource "oci_load_balancer_backend_set" "openshift_cluster_api_backend_internal" {
     health_checker {
-        protocol    = "HTTPS"
-        port        = 22623
-        url_path    = "/healthz"
+        protocol    = "HTTP"
+        port        = 6080
         return_code = 200
+        url_path    = "/readyz"
+        interval_ms = 10000
+        timeout_in_millis  = 3000
+        retries            = 3
     }
-    name                     = "openshift_cluster_infra-mcs_backend"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
-    policy                   = "FIVE_TUPLE"
-    is_preserve_source       = false
-    depends_on               = [oci_network_load_balancer_listener.openshift_cluster_ingress_https]
+    name                     = "openshift_cluster_api_backend"
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
+    policy                   = "LEAST_CONNECTIONS"
+    depends_on               = [oci_load_balancer_load_balancer.openshift_internal_lb]
+}
+ 
+resource "oci_load_balancer_listener" "openshift_cluster_api_listener_internal" {
+    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_internal.name
+    name                     = "openshift_cluster_api_listener"
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
+    port                     = 6443
+    protocol                 = "TCP"
+    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_api_backend_internal]
 }
 
-resource "oci_network_load_balancer_listener" "openshift_cluster_infra-mcs" {
-    default_backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend.name
+resource "oci_load_balancer_backend_set" "openshift_cluster_infra-mcs_backend" {
+    health_checker {
+        protocol    = "HTTP"
+        port        = 22624
+        return_code = 200
+        url_path    = "/healthz"
+        interval_ms = 10000
+        timeout_in_millis  = 3000
+        retries            = 3
+    }
     name                     = "openshift_cluster_infra-mcs"
-    network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
+    policy                   = "LEAST_CONNECTIONS"
+    depends_on               = [oci_load_balancer_load_balancer.openshift_internal_lb]
+}
+ 
+resource "oci_load_balancer_listener" "openshift_cluster_infra-mcs" {
+    default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend.name
+    name                     = "openshift_cluster_infra-mcs"
+    load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
     port                     = 22623
     protocol                 = "TCP"
-    depends_on               = [oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend]
+    depends_on               = [oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend]
 }
 
+resource "oci_load_balancer_backend_set" "openshift_cluster_infra-mcs_backend_2" {
+  health_checker {
+        protocol    = "HTTP"
+        port        = 22624
+        return_code = 200
+        url_path    = "/healthz"
+        interval_ms = 10000
+        timeout_in_millis  = 3000
+        retries            = 3
+    }
+  name                     = "openshift_cluster_infra-mcs_2"
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
+  policy                   = "LEAST_CONNECTIONS"
+  depends_on               = [oci_load_balancer_load_balancer.openshift_internal_lb]
+}
+ 
+resource "oci_load_balancer_listener" "openshift_cluster_infra-mcs_2" {
+  default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2.name
+  name                     = "openshift_cluster_infra-mcs_2"
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_internal_lb.id
+  port                     = 22624
+  protocol                 = "TCP"
+  depends_on               = [oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2]
+}
+ 
 resource "oci_identity_dynamic_group" "openshift_master_nodes" {
     compartment_id = var.tenancy_ocid
-    description    = "OpenShift master nodes" 
+    description    = "OpenShift master nodes"
     matching_rule  = "all {instance.compartment.id='${var.compartment_ocid}', tag.openshift-${var.cluster_name}.instance-role.value='master'}"
     name           = "${var.cluster_name}_master_nodes"
     provider       = oci.home
 }
-
+ 
 resource "oci_identity_policy" "openshift_master_nodes" {
-    compartment_id = var.tenancy_ocid
+    compartment_id = var.compartment_ocid
     description    = "OpenShift master nodes instance principal"
     name           = "${var.cluster_name}_master_nodes"
     statements     = [
@@ -602,7 +715,7 @@ resource "oci_identity_policy" "openshift_master_nodes" {
     ]
     provider       = oci.home
 }
-
+ 
 resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
   compartment_id = var.tenancy_ocid
   description    = "OpenShift worker nodes"
@@ -610,7 +723,7 @@ resource "oci_identity_dynamic_group" "openshift_worker_nodes" {
   name           = "${var.cluster_name}_worker_nodes"
   provider       = oci.home
 }
-
+ 
 resource oci_dns_zone openshift {
   compartment_id = var.compartment_ocid
   name           = var.zone_dns
@@ -619,53 +732,53 @@ resource oci_dns_zone openshift {
   zone_type      = "PRIMARY"
   depends_on     = [oci_core_subnet.private]
 }
-
+ 
 resource oci_dns_rrset openshift_api {
   domain = "api.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "api.${var.cluster_name}.${var.zone_dns}"
     rdata  = var.enable_private_dns ? local.lb_private_addr : local.lb_public_addr
     rtype  = "A"
-    ttl    = "30"
+    ttl    = "3600"
   }
   rtype           = "A"
   zone_name_or_id = oci_dns_zone.openshift.id
 }
-
+ 
 resource oci_dns_rrset openshift_apps {
   domain = "*.apps.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "*.apps.${var.cluster_name}.${var.zone_dns}"
     rdata  = var.enable_private_dns ? local.lb_private_addr : local.lb_public_addr
     rtype  = "A"
-    ttl    = "30"
+    ttl    = "3600"
   }
   rtype           = "A"
   zone_name_or_id = oci_dns_zone.openshift.id
 }
-
+ 
 resource oci_dns_rrset openshift_api_int {
   domain = "api-int.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "api-int.${var.cluster_name}.${var.zone_dns}"
-    rdata  = var.enable_private_dns ? local.lb_private_addr : local.lb_public_addr
+    rdata  = local.lb_private_addr
     rtype  = "A"
-    ttl    = "30"
+    ttl    = "3600"
   }
   rtype           = "A"
   zone_name_or_id = oci_dns_zone.openshift.id
 }
-
+ 
 resource "time_sleep" "wait_180_seconds" {
   depends_on = [oci_core_vcn.openshift_vcn]
   create_duration = "180s"
 }
-
+ 
 data "oci_core_vcn_dns_resolver_association" "dns_resolver_association" {
   vcn_id     = oci_core_vcn.openshift_vcn.id
   depends_on = [time_sleep.wait_180_seconds]
 }
-
+ 
 data "oci_dns_resolver" "dns_resolver" {
   depends_on = [
     data.oci_core_vcn_dns_resolver_association.dns_resolver_association
@@ -673,7 +786,7 @@ data "oci_dns_resolver" "dns_resolver" {
   resolver_id = data.oci_core_vcn_dns_resolver_association.dns_resolver_association.dns_resolver_id
   scope       = "PRIVATE"
 }
-
+ 
 resource oci_core_instance_configuration master_node_config {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
@@ -708,27 +821,33 @@ resource oci_core_instance_configuration master_node_config {
     }
   }
 }
-
+ 
 resource oci_core_instance_pool master_nodes {
   count                     = local.create_openshift_instance_pools ? 1 : 0
   compartment_id            = var.compartment_ocid
   display_name              = "${var.cluster_name}-master"
   instance_configuration_id = oci_core_instance_configuration.master_node_config[0].id
   load_balancers {
-    backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_api_backend.name
-    load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_external.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id
     port             = "6443"
     vnic_selection   = "PrimaryVnic"
   }
   load_balancers {
-    backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend.name
-    load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_internal.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_internal_lb.id
+    port             = "6443"
+    vnic_selection   = "PrimaryVnic"
+  }
+  load_balancers {
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_internal_lb.id
     port             = "22623"
     vnic_selection   = "PrimaryVnic"
   }
   load_balancers {
-    backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2.name
-    load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_internal_lb.id
     port             = "22624"
     vnic_selection   = "PrimaryVnic"
   }
@@ -738,13 +857,14 @@ resource oci_core_instance_pool master_nodes {
   }
   size       = var.master_count
   depends_on = [
-    oci_network_load_balancer_backend_set.openshift_cluster_api_backend,
-    oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend,
-    oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2,
+    oci_load_balancer_backend_set.openshift_cluster_api_backend_external,
+    oci_load_balancer_backend_set.openshift_cluster_api_backend_internal,
+    oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend,
+    oci_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2,
     oci_core_instance_configuration.master_node_config,
   ]
 }
-
+ 
 resource oci_core_instance_configuration worker_node_config {
   count          = local.create_openshift_instance_pools ? 1 : 0
   compartment_id = var.compartment_ocid
@@ -779,21 +899,21 @@ resource oci_core_instance_configuration worker_node_config {
     }
   }
 }
-
+ 
 resource oci_core_instance_pool worker_nodes {
   count                     = local.create_openshift_instance_pools ? 1 : 0
   compartment_id            = var.compartment_ocid
   display_name              = "${var.cluster_name}-worker"
   instance_configuration_id = oci_core_instance_configuration.worker_node_config[0].id
   load_balancers {
-    backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
-    load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id
     port             = "443"
     vnic_selection   = "PrimaryVnic"
   }
   load_balancers {
-    backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_ingress_http_backend.name
-    load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_external_lb.id
     port             = "80"
     vnic_selection   = "PrimaryVnic"
   }
@@ -803,20 +923,20 @@ resource oci_core_instance_pool worker_nodes {
   }
   size       = var.worker_count
   depends_on = [
-    oci_network_load_balancer_backend_set.openshift_cluster_ingress_https_backend,
-    oci_network_load_balancer_backend_set.openshift_cluster_ingress_http_backend,
+    oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend,
+    oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend,
     oci_core_instance_configuration.worker_node_config,
   ]
 }
-
+ 
 output "open_shift_lb_private_addr" {
   value = local.lb_private_addr
 }
-
+ 
 output "open_shift_lb_public_addr" {
   value = local.lb_public_addr
 }
-
+ 
 output "oci_ccm_config" {
   value = <<OCICCMCONFIG
 useInstancePrincipals: true
@@ -833,41 +953,4 @@ rateLimiter:
   rateLimitQPSWrite: 20.0
   rateLimitBucketWrite: 5
   OCICCMCONFIG
-}
-
-resource "oci_network_load_balancer_backend_set" "openshift_cluster_infra-mcs_backend_2" {
-  health_checker {
-    protocol           = "TCP"
-    port               = 22624
-    interval_in_millis = 10000
-    timeout_in_millis  = 3000
-    retries            = 3
-  }
-  name                     = "openshift_cluster_infra-mcs_backend_2"
-  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
-  policy                   = "FIVE_TUPLE"
-  is_preserve_source       = false
-  depends_on               = [oci_network_load_balancer_listener.openshift_cluster_infra-mcs]
-}
-
-resource "oci_network_load_balancer_listener" "openshift_cluster_infra-mcs_2" {
-  default_backend_set_name = oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2.name
-  name                     = "openshift_cluster_infra-mcs_2"
-  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.openshift_lb.id
-  port                     = 22624
-  protocol                 = "TCP"
-  depends_on               = [oci_network_load_balancer_backend_set.openshift_cluster_infra-mcs_backend_2]
-}
-
-resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_7" {
-  network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
-  protocol                  = "6"
-  direction                 = "INGRESS"
-  source                    = local.anywhere
-  tcp_options {
-    destination_port_range {
-      min = 22624
-      max = 22624
-    }
-  }
 }

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -32,12 +32,12 @@ variable master_boot_size {
 variable master_boot_volume_vpus_per_gb {
     default     = 90
     type        = number
-    description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each master node. The default value is 60. "
+    description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each master node. The default value is 90. "
 }
 variable worker_count {
     default     = 4
     type        = number
-    description = "The number of worker nodes in the cluster. The default value is 3. "
+    description = "The number of worker nodes in the cluster. The default value is 4. "
 }
 variable worker_shape {
     default     = "VM.Standard.E4.Flex"
@@ -51,7 +51,7 @@ variable worker_ocpu {
 variable worker_boot_volume_vpus_per_gb {
     default     = 30
     type        = number
-    description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each worker node. The default value is 20. "
+    description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each worker node. The default value is 30. "
 }
 variable worker_memory {
     default     = 16
@@ -130,9 +130,9 @@ data oci_identity_region_subscriptions region_subscriptions {
     values = [var.region]
   }
 }
+
 data oci_identity_regions regions {}
- 
- 
+
 locals {
   region_map = {
     for r in data.oci_identity_regions.regions.regions :

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -403,26 +403,13 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_3"
   source                    = local.anywhere
   tcp_options {
     destination_port_range {
-      min = 22623
-      max = 22623
-    }
-  }
-}
-
-resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_4" {
-  network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
-  protocol                  = "6"
-  direction                 = "INGRESS"
-  source                    = local.anywhere
-  tcp_options {
-    destination_port_range {
       min = 80
       max = 80
     }
   }
 }
 
-resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_5" {
+resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_4" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = "6"
   direction                 = "INGRESS"
@@ -435,24 +422,11 @@ resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_5"
   }
 }
 
-resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_6" {
+resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_5" {
   network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
   protocol                  = local.all_protocols
   direction                 = "INGRESS"
   source                    = var.vcn_cidr
-}
-
-resource "oci_core_network_security_group_security_rule" "cluster_lb_nsg_rule_7" {
-  network_security_group_id = oci_core_network_security_group.cluster_lb_nsg.id
-  protocol                  = "6"
-  direction                 = "INGRESS"
-  source                    = local.anywhere
-  tcp_options {
-    destination_port_range {
-      min = 22624
-      max = 22624
-    }
-  }
 }
 
 resource "oci_core_network_security_group" "cluster_controlplane_nsg" {
@@ -473,20 +447,6 @@ resource "oci_core_network_security_group_security_rule" "cluster_controlplane_n
   protocol                  = local.all_protocols
   direction                 = "INGRESS"
   source                    = var.vcn_cidr
-}
-
-# new nsg rule for api 
-resource "oci_core_network_security_group_security_rule" "cluster_controlplane_nsg_3" {
-  network_security_group_id = oci_core_network_security_group.cluster_controlplane_nsg.id
-  protocol                  = "6"
-  direction                 = "INGRESS"
-  source                    = local.anywhere
-  tcp_options {
-    destination_port_range {
-      min = 6443
-      max = 6443
-    }
-  }
 }
 
 resource "oci_core_network_security_group" "cluster_compute_nsg" {

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -37,7 +37,7 @@ variable "master_boot_volume_vpus_per_gb" {
 variable "worker_count" {
   default     = 3
   type        = number
-  description = "The number of worker nodes in the cluster. The default value is 4. "
+  description = "The number of worker nodes in the cluster. The default value is 3. "
 }
 variable "worker_shape" {
   default     = "VM.Standard.E4.Flex"

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -152,7 +152,7 @@ locals {
   all_protocols                   = "all"
   anywhere                        = "0.0.0.0/0"
   create_openshift_instance_pools = true
-  pool_formatter_id = join("", ["$", "{launchCount}"])
+  pool_formatter_id               = join("", ["$", "{launchCount}"])
 }
 
 data "oci_identity_availability_domain" "availability_domain" {
@@ -784,10 +784,10 @@ resource "oci_core_instance_configuration" "master_node_config" {
 }
 
 resource "oci_core_instance_pool" "master_nodes" {
-  count                     = local.create_openshift_instance_pools ? 1 : 0
-  compartment_id            = var.compartment_ocid
-  display_name              = "${var.cluster_name}-master"
-  instance_configuration_id = oci_core_instance_configuration.master_node_config[0].id
+  count                           = local.create_openshift_instance_pools ? 1 : 0
+  compartment_id                  = var.compartment_ocid
+  display_name                    = "${var.cluster_name}-master"
+  instance_configuration_id       = oci_core_instance_configuration.master_node_config[0].id
   instance_display_name_formatter = "${var.cluster_name}-master-${local.pool_formatter_id}"
   instance_hostname_formatter     = "${var.cluster_name}-master-${local.pool_formatter_id}"
   load_balancers {
@@ -864,10 +864,10 @@ resource "oci_core_instance_configuration" "worker_node_config" {
 }
 
 resource "oci_core_instance_pool" "worker_nodes" {
-  count                     = local.create_openshift_instance_pools ? 1 : 0
-  compartment_id            = var.compartment_ocid
-  display_name              = "${var.cluster_name}-worker"
-  instance_configuration_id = oci_core_instance_configuration.worker_node_config[0].id
+  count                           = local.create_openshift_instance_pools ? 1 : 0
+  compartment_id                  = var.compartment_ocid
+  display_name                    = "${var.cluster_name}-worker"
+  instance_configuration_id       = oci_core_instance_configuration.worker_node_config[0].id
   instance_display_name_formatter = "${var.cluster_name}-worker-${local.pool_formatter_id}"
   instance_hostname_formatter     = "${var.cluster_name}-worker-${local.pool_formatter_id}"
   load_balancers {


### PR DESCRIPTION
Clusters created using this updated TF pass most OPCT tests. Main areas of improvement are better etcd latency and no more request timeouts/client connection lost.

- Increased default master boot volume size from 500 -> 1024 and VPUs from 60 -> 90 to help with Disk I/O (etcd)
- Increased default worker node count from 3 -> 4 and their VPUs from 20 -> 30
- Removed NLB and replaced with 2 ALBs each set to have min/max bandwidth from 10 MB/s - 500 MB/s
  - Private internal load balancer that listens on ports 6443, 22623, 22624 and directs traffic to master nodes. DNS A 
record for api-int is always pointing at the internal load balancer IP
  - Public external load balancer that listens on ports 80, 443, 6443. Traffic on ports 80 and 443 are directed to worker nodes, 6443 is directed to master nodes. DNS A records for api and *.apps are pointing here.
- Remove BIOS as an option for the image capability schema so customers can’t change it from UEFI_64
- Move policy for master_nodes to compartment instead of tenancy