### PR TITLE
update the placeholder secrets for CCM to consistent format

### DIFF
--- a/custom_manifests/manifests/oci-ccm.yml
+++ b/custom_manifests/manifests/oci-ccm.yml
@@ -196,14 +196,14 @@ metadata:
   namespace: oci-cloud-controller-manager
 stringData:
   cloud-provider.yaml: |
-    auth:
-      region: $OCI_CLI_REGION
-      useInstancePrincipals: true
-      compartment: $COMPARTMENT_ID
+    useInstancePrincipals: true
+    compartment: $COMPARTMENT_ID
     vcn: $OCP_VCN_ID
     loadBalancer:
       subnet1: $OCP_SUBNET_ID
-      securityListManagementMode: None
+      securityListManagementMode: Frontend
+      securityLists:
+        $OCP_SUBNET_ID: $OPC_SEC_LIST_ID
     rateLimiter:
       rateLimitQPSRead: 20.0
       rateLimitBucketRead: 5

--- a/custom_manifests/manifests/oci-csi.yml
+++ b/custom_manifests/manifests/oci-csi.yml
@@ -26,14 +26,14 @@ metadata:
   namespace: oci-csi
 stringData:
   config.yaml: |
-    auth:
-      region: $OCI_CLI_REGION
-      useInstancePrincipals: true
-      compartment: $COMPARTMENT_ID
+    useInstancePrincipals: true
+    compartment: $COMPARTMENT_ID
     vcn: $OCP_VCN_ID
     loadBalancer:
       subnet1: $OCP_SUBNET_ID
-      securityListManagementMode: None
+      securityListManagementMode: Frontend
+      securityLists:
+        $OCP_SUBNET_ID: $OPC_SEC_LIST_ID
     rateLimiter:
       rateLimitQPSRead: 20.0
       rateLimitBucketRead: 5


### PR DESCRIPTION
### Description
I updated the placeholder secret for CCM in oci-ccm.yml and oci-csi.yml to match custom_manifests/README.md and the output of infrastructure.tf

### Motivation
This change should reduce confusion for customers when replacing the placeholder secret and create consistency.

### Testing
Ran pre-commit to format the yaml files