### PR TITLE
[Issue #26]: add control plane instances to ingress backend sets by default

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -844,6 +844,18 @@ resource "oci_core_instance_pool" "control_plane_nodes" {
     vnic_selection   = "PrimaryVnic"
   }
   load_balancers {
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+    port             = "443"
+    vnic_selection   = "PrimaryVnic"
+  }
+  load_balancers {
+    backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend.name
+    load_balancer_id = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+    port             = "80"
+    vnic_selection   = "PrimaryVnic"
+  }
+  load_balancers {
     backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_internal.name
     load_balancer_id = oci_load_balancer_load_balancer.openshift_api_int_lb.id
     port             = "6443"


### PR DESCRIPTION
### Description
This PR modified the control plane instance pool to add those control plane instances to the ingress load balancer by default to cover scenarios where there are not enough compute nodes to schedule the ingress pods onto. 

To deploy a cluster with this configuration, I needed to submit a service limit increase for the number of load balancers attached to an instance pool from 5 -> 6. I requested that this limit be increased globally, but it may have just been increased for the rhelcert tenancy only. I will update when I know for certain what the scope of the limit increase was. If the increase was only applied to our tenancy, and they choose to not increase the limit globally, then customers would have to submit a service limit increase themselves for their tenancy before this configuration could be deployed.

### Motivation
This change addresses Issue #26. Customers need to be able to create clusters with less than 5 nodes, or SNO clusters.

### Testing
I've created 2 clusters using this setup; the first with 3 control planes and 1 compute, and the second as a SNO cluster with only 1 control plane node. Both of these installations were successful.

3 control planes + 1 compute:
![Screenshot 2024-05-13 at 2 25 00 PM](https://github.com/oracle-quickstart/oci-openshift/assets/17482454/f6fddb98-835f-4611-9817-3a4b2ce990b5)
![Screenshot 2024-05-13 at 2 25 07 PM](https://github.com/oracle-quickstart/oci-openshift/assets/17482454/2cc313cc-2bef-4bec-8266-db23a8d3d814)
<img width="771" alt="Screenshot 2024-05-13 at 2 25 28 PM" src="https://github.com/oracle-quickstart/oci-openshift/assets/17482454/010b47e2-9bfb-4312-b55c-2783fea647e8">
![Screenshot 2024-05-13 at 2 27 26 PM](https://github.com/oracle-quickstart/oci-openshift/assets/17482454/e7517640-427f-4a25-b0fa-6ac7188482e9)

SNO cluster with 1 control plane:
![Screenshot 2024-05-13 at 3 48 57 PM](https://github.com/oracle-quickstart/oci-openshift/assets/17482454/17d2e6b0-c5d0-431c-b35a-18a8ee7d2452)
![Screenshot 2024-05-13 at 3 49 07 PM](https://github.com/oracle-quickstart/oci-openshift/assets/17482454/1fe4bb02-ef0f-4dcb-937c-e1c2a2069302)
<img width="767" alt="Screenshot 2024-05-13 at 3 49 19 PM" src="https://github.com/oracle-quickstart/oci-openshift/assets/17482454/e06e48ee-bdfa-4f8b-864b-b1977a151170">
![Screenshot 2024-05-13 at 3 49 35 PM](https://github.com/oracle-quickstart/oci-openshift/assets/17482454/c9d1b065-6ef2-4130-a3c0-5bba8bf9db91)
