### PR TITLE
update readme with latest documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@ This Terraform code is specifically designed for the OpenShift on Oracle Cloud I
 
 See the following for installation instructions:
 
-**OpenShift 4.14 on Oracle Cloud Infrastructure (OCI) [Technology Preview]**
-- Connected deployments using Assisted Installer: https://docs.openshift.com/container-platform/4.14/installing/installing_oci/installing-oci-assisted-installer.html
-- Disconnected or air gapped deployments using Agent-based Installer: https://docs.openshift.com/container-platform/4.14/installing/installing_oci/installing-oci-agent-based-installer.html
-
-**OpenShift 4.15 on Oracle Cloud Infrastructure (OCI) [Technology Preview]**
-- Connected deployments using Assisted Installer: https://docs.openshift.com/container-platform/4.15/installing/installing_oci/installing-oci-assisted-installer.html
-- Disconnected or air gapped deployments using Agent-based Installer: https://docs.openshift.com/container-platform/4.15/installing/installing_oci/installing-oci-agent-based-installer.html
+**Redhat OpenShift latest version on Oracle Cloud Infrastructure (OCI)**
+- OCI documentation - https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/overview.htm
+- Connected deployments using Assisted Installer: https://docs.openshift.com/container-platform/latest/installing/installing_oci/installing-oci-assisted-installer.html
+- Disconnected or air gapped deployments using Agent-based Installer: https://docs.openshift.com/container-platform/latest/installing/installing_oci/installing-oci-agent-based-installer.html
 
 ## Resources Created:
 


### PR DESCRIPTION
### Description

OCI and Redhat GA'd Openshift on OCI 30th April 2024 and it's now available to everyone. It has moved out of the technology preview state from the Redhat side.

### Motivation

This pull request focuses on updating the readme to remove the reference to the technology preview state. 

### Testing

This is a documentation update and below is the screenshot of how it would look like. 
![image](https://github.com/user-attachments/assets/546b23fd-3923-495e-811d-13da7fe903b0)


