### PR TITLE
Workflows for testing Terraform changes

### DIFF
--- a/.github/workflows/change-test.yml
+++ b/.github/workflows/change-test.yml
@@ -63,8 +63,9 @@ jobs:
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
-      # - name: Destroy RMS Stack
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-stack
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+      - name: Destroy RMS Stack
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: destroy-stack
+        continue-on-error: true
+        with:
+          command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'

--- a/.github/workflows/change-test.yml
+++ b/.github/workflows/change-test.yml
@@ -39,33 +39,32 @@ jobs:
           fi
 
       - name: Create RMS Stack
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: create-stack
         with:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}--${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
       - name: RMS Stack Plan Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-plan-job
         with:
           command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: RMS Stack Apply Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-apply-job
         with:
           command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: RMS Stack Destroy Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-destroy-job
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: Destroy RMS Stack
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: destroy-stack
-        continue-on-error: true
         with:
           command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'

--- a/.github/workflows/change-test.yml
+++ b/.github/workflows/change-test.yml
@@ -1,0 +1,70 @@
+name: Infrastructure Change Test
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - "infrastructure.tf"
+      - 'infrastructure/**'
+jobs:
+  change-test:
+    runs-on: ubuntu-latest
+    name: Create and teardown cluster infrastructure
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+      OPENSHIFT_IMAGE_SOURCE_URI: ${{ secrets.OPENSHIFT_IMAGE_SOURCE_URI }}
+      COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
+      ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
+      CLUSTER_NAME: change-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set NOW env variable
+        run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
+      - name: Create Terraform ZIP
+        run: |
+          if [ -f infrastructure.tf ]; then
+            zip infrastructure.zip infrastructure.tf
+          elif [ -d infrastructure ]; then
+            zip -j infrastructure.zip infrastructure/data.tf infrastructure/locals.tf infrastructure/main.tf infrastructure/output.tf infrastructure/schema.yaml infrastructure/variables.tf
+          else
+            echo "Could not find infrastructure.tf or infrastructure directory"
+            exit 1
+          fi
+
+      - name: Create RMS Stack
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: create-stack
+        with:
+          command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}--${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
+          query: 'data.id'
+
+      - name: RMS Stack Plan Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-plan-job
+        with:
+          command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      - name: RMS Stack Apply Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-apply-job
+        with:
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      - name: RMS Stack Destroy Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-destroy-job
+        with:
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      # - name: Destroy RMS Stack
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-stack
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'

--- a/.github/workflows/change-test.yml
+++ b/.github/workflows/change-test.yml
@@ -55,13 +55,13 @@ jobs:
         uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-apply-job
         with:
-          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: RMS Stack Destroy Job
         uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-destroy-job
         with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: Destroy RMS Stack
         uses: oracle-actions/run-oci-cli-command@v1.3.2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,64 +3,7 @@ on:
   schedule:
     - cron: "20 5 */2 * *"
 jobs:
-  smoke-test-vm:
-    runs-on: ubuntu-latest
-    name: Create VM cluster infrastructure
-    env:
-      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
-      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
-      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
-      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
-      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
-      OPENSHIFT_IMAGE_SOURCE_URI: ${{ secrets.OPENSHIFT_IMAGE_SOURCE_URI }}
-      COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
-      ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
-      CLUSTER_NAME: smoke-test-vm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set NOW env variable
-        run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
-
-      - name: Create Terraform ZIP
-        run: |
-          if [ -f infrastructure.tf ]; then
-            zip infrastructure.zip infrastructure.tf
-          elif [ -d infrastructure ]; then
-            zip -j infrastructure.zip infrastructure/data.tf infrastructure/locals.tf infrastructure/main.tf infrastructure/output.tf infrastructure/schema.yaml infrastructure/variables.tf
-          else
-            echo "Could not find infrastructure.tf or infrastructure directory"
-            exit 1
-          fi
-
-      - name: Create RMS Stack
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: create-stack
-        with:
-          command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
-          query: 'data.id'
-
-      - name: RMS Stack Plan Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: stack-plan-job
-        with:
-          command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
-
-      - name: RMS Stack Apply Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: stack-apply-job
-        with:
-          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
-      
-      - name: Teardown VM Infrastructure
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: teardown-vm-infra
-        with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
-
-  smoke-test-bm:
-    needs: [smoke-test-vm]
+  smoke-test-bm-single-ad:
     runs-on: ubuntu-latest
     name: Create BM cluster infrastructure
     env:
@@ -124,7 +67,7 @@ jobs:
   
 
   smoke-test-vm-multi-ad:
-    needs: [smoke-test-bm]
+    needs: [smoke-test-bm-single-ad]
     runs-on: ubuntu-latest
     name: Create VM cluster infrastructure in multi-ad region
     env:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -51,13 +51,13 @@ jobs:
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: stack-apply-job
         with:
-          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
       
       - name: Teardown VM Infrastructure
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: teardown-vm-infra
         with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
   smoke-test-bm:
     needs: [smoke-test-vm]
@@ -108,13 +108,13 @@ jobs:
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: stack-apply-job
         with:
-          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
       
       - name: Teardown BM Infrastructure
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: teardown-bm-infra
         with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
   smoke-test-vm-multi-ad:
     needs: [smoke-test-bm]
@@ -166,10 +166,10 @@ jobs:
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: stack-apply-job
         with:
-          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: Teardown VM Multi AD Infrastructure
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: teardown-vm-multi-ad-infra
         with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set NOW env variable
         run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
@@ -42,7 +42,7 @@ jobs:
         with:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
-      
+
       - name: Output Stack ID
         id: output-stack-id
         env:
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set NOW env variable
         run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
@@ -140,7 +140,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set NOW env variable
         run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
@@ -199,14 +199,14 @@ jobs:
         id: teardown-vm-infra
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
-      
+
       - name: Teardown BM Infrastructure
         if: ${{ needs.smoke-test-bm.result == 'success' }}
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: teardown-bm-infra
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
-      
+
       - name: Teardown VM multi-ad Infrastructure
         if: ${{ needs.smoke-test-vm-multi-ad.result == 'success' }}
         uses: oracle-actions/run-oci-cli-command@v1.3.1
@@ -229,7 +229,7 @@ jobs:
         continue-on-error: true
         with:
           command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
-     
+
       - name: Destroy VM multi-ad RMS Stack
         if: ${{ steps.teardown-vm-multi-ad-infra.outcome == 'success' }}
         uses: oracle-actions/run-oci-cli-command@v1.3.1

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -214,23 +214,26 @@ jobs:
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
 
-      # - name: Destroy VM RMS Stack
-      #   if: ${{ steps.teardown-vm-infra.outcome == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-vm-stack
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
+      - name: Destroy VM RMS Stack
+        if: ${{ steps.teardown-vm-infra.outcome == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: destroy-vm-stack
+        continue-on-error: true
+        with:
+          command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
 
-      # - name: Destroy BM RMS Stack
-      #   if: ${{ steps.teardown-bm-infra.outcome == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-bm-stack
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
+      - name: Destroy BM RMS Stack
+        if: ${{ steps.teardown-bm-infra.outcome == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: destroy-bm-stack
+        continue-on-error: true
+        with:
+          command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
      
-      # - name: Destroy VM multi-ad RMS Stack
-      #   if: ${{ steps.teardown-vm-multi-ad-infra.outcome == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-vm-multi-ad-stack
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
+      - name: Destroy VM multi-ad RMS Stack
+        if: ${{ steps.teardown-vm-multi-ad-infra.outcome == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: destroy-vm-multi-ad-stack
+        continue-on-error: true
+        with:
+          command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -92,29 +92,36 @@ jobs:
           fi
 
       - name: Create RMS Stack
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: create-stack
         with:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"control_plane_shape\": \"BM.Standard3.64\", \"control_plane_ocpu\": \"64\", \"control_plane_memory\": \"1024\", \"compute_shape\": \"BM.Standard3.64\", \"compute_ocpu\": \"64\", \"compute_memory\": \"1024\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
       - name: RMS Stack Plan Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-plan-job
         with:
           command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: RMS Stack Apply Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-apply-job
         with:
           command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
       
       - name: Teardown BM Infrastructure
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: teardown-bm-infra
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      - name: Destroy RMS Stack
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
+        id: destroy-stack
+        with:
+          command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+  
 
   smoke-test-vm-multi-ad:
     needs: [smoke-test-bm]
@@ -150,26 +157,32 @@ jobs:
           fi
 
       - name: Create RMS Stack
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: create-stack
         with:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.MUTLI_AD_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
       - name: RMS Stack Plan Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-plan-job
         with:
           command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: RMS Stack Apply Job
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: stack-apply-job
         with:
           command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
       - name: Teardown VM Multi AD Infrastructure
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
         id: teardown-vm-multi-ad-infra
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 2400 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      - name: Destroy RMS Stack
+        uses: oracle-actions/run-oci-cli-command@v1.3.2
+        id: destroy-stack
+        with:
+          command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -214,23 +214,23 @@ jobs:
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
 
-      - name: Destroy VM RMS Stack
-        if: ${{ needs.smoke-test-vm.result == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: destroy-vm-stack
-        with:
-          command: 'resource-manager stack destroy --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
+      # - name: Destroy VM RMS Stack
+      #   if: ${{ steps.teardown-vm-infra.outcome == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-vm-stack
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
 
-      - name: Destroy BM RMS Stack
-        if: ${{ needs.smoke-test-bm.result == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: destroy-bm-stack
-        with:
-          command: 'resource-manager stack destroy --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
+      # - name: Destroy BM RMS Stack
+      #   if: ${{ steps.teardown-bm-infra.outcome == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-bm-stack
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
      
-      - name: Destroy VM multi-ad RMS Stack
-        if: ${{ needs.smoke-test-vm-multi-ad.result == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: destroy-vm-multi-ad-stack
-        with:
-          command: 'resource-manager stack destroy --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
+      # - name: Destroy VM multi-ad RMS Stack
+      #   if: ${{ steps.teardown-vm-multi-ad-infra.outcome == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-vm-multi-ad-stack
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,6 +1,5 @@
 name: Infrastructure Smoke Test
 on:
-  push:
   schedule:
     - cron: "20 5 */2 * *"
 jobs:
@@ -17,8 +16,6 @@ jobs:
       COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
       ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
       CLUSTER_NAME: smoke-test-vm
-    # outputs:
-    #   stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,13 +41,6 @@ jobs:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
-      # - name: Output Stack ID
-      #   id: output-stack-id
-      #   env:
-      #     stack_id: ${{ steps.create-stack.outputs.raw_output }}
-      #   run: |
-      #     echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
-
       - name: RMS Stack Plan Job
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: stack-plan-job
@@ -69,13 +59,6 @@ jobs:
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
-      # - name: Destroy VM RMS Stack
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-vm-stack
-      #   continue-on-error: true
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
-
   smoke-test-bm:
     needs: [smoke-test-vm]
     runs-on: ubuntu-latest
@@ -90,8 +73,6 @@ jobs:
       COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
       ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
       CLUSTER_NAME: smoke-test-bm
-    # outputs:
-    #   stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,13 +98,6 @@ jobs:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"control_plane_shape\": \"BM.Standard3.64\", \"control_plane_ocpu\": \"64\", \"control_plane_memory\": \"1024\", \"compute_shape\": \"BM.Standard3.64\", \"compute_ocpu\": \"64\", \"compute_memory\": \"1024\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
-      # - name: Output Stack ID
-      #   id: output-stack-id
-      #   env:
-      #     stack_id: ${{ steps.create-stack.outputs.raw_output }}
-      #   run: |
-      #     echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
-
       - name: RMS Stack Plan Job
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: stack-plan-job
@@ -142,13 +116,6 @@ jobs:
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
-      # - name: Destroy BM RMS Stack
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-bm-stack
-      #   continue-on-error: true
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
-
   smoke-test-vm-multi-ad:
     needs: [smoke-test-bm]
     runs-on: ubuntu-latest
@@ -164,8 +131,6 @@ jobs:
       ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
       CLUSTER_NAME: smoke-test-vm-multi-ad
       MUTLI_AD_REGION: eu-frankfurt-1
-    # outputs:
-    #   stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -191,13 +156,6 @@ jobs:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.MUTLI_AD_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
-      # - name: Output Stack ID
-      #   id: output-stack-id
-      #   env:
-      #     stack_id: ${{ steps.create-stack.outputs.raw_output }}
-      #   run: |
-      #     echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
-
       - name: RMS Stack Plan Job
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: stack-plan-job
@@ -215,67 +173,3 @@ jobs:
         id: teardown-vm-multi-ad-infra
         with:
           command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
-
-      # - name: Destroy VM Multi AD RMS Stack
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-vm-multi-ad-stack
-      #   continue-on-error: true
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
-
-  # teardown-stacks:
-  #   if: ${{ !cancelled() }}
-  #   needs: [smoke-test-vm, smoke-test-bm, smoke-test-vm-multi-ad]
-    # runs-on: ubuntu-latest
-    # name: Teardown cluster infrastructure
-    # env:
-    #   OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
-    #   OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
-    #   OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
-    #   OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
-    #   OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
-    # steps:
-    #   - name: Teardown VM Infrastructure
-    #     if: ${{ needs.smoke-test-vm.result == 'success' }}
-    #     uses: oracle-actions/run-oci-cli-command@v1.3.1
-    #     id: teardown-vm-infra
-    #     with:
-    #       command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
-
-    #   - name: Teardown BM Infrastructure
-      #   if: ${{ needs.smoke-test-bm.result == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: teardown-bm-infra
-      #   with:
-      #     command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
-
-      # - name: Teardown VM multi-ad Infrastructure
-      #   if: ${{ needs.smoke-test-vm-multi-ad.result == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: teardown-vm-multi-ad-infra
-      #   with:
-      #     command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
-
-      # - name: Destroy VM RMS Stack
-      #   if: ${{ steps.teardown-vm-infra.outcome == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-vm-stack
-      #   continue-on-error: true
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
-
-      # - name: Destroy BM RMS Stack
-      #   if: ${{ steps.teardown-bm-infra.outcome == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-bm-stack
-      #   continue-on-error: true
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
-
-      # - name: Destroy VM multi-ad RMS Stack
-      #   if: ${{ steps.teardown-vm-multi-ad-infra.outcome == 'success' }}
-      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
-      #   id: destroy-vm-multi-ad-stack
-      #   continue-on-error: true
-      #   with:
-      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,5 +1,6 @@
 name: Infrastructure Smoke Test
 on:
+  push:
   schedule:
     - cron: "20 5 */2 * *"
 jobs:
@@ -16,8 +17,8 @@ jobs:
       COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
       ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
       CLUSTER_NAME: smoke-test-vm
-    outputs:
-      stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
+    # outputs:
+    #   stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,12 +44,12 @@ jobs:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
-      - name: Output Stack ID
-        id: output-stack-id
-        env:
-          stack_id: ${{ steps.create-stack.outputs.raw_output }}
-        run: |
-          echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
+      # - name: Output Stack ID
+      #   id: output-stack-id
+      #   env:
+      #     stack_id: ${{ steps.create-stack.outputs.raw_output }}
+      #   run: |
+      #     echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: RMS Stack Plan Job
         uses: oracle-actions/run-oci-cli-command@v1.3.1
@@ -61,8 +62,22 @@ jobs:
         id: stack-apply-job
         with:
           command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+      
+      - name: Teardown VM Infrastructure
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: teardown-vm-infra
+        with:
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      # - name: Destroy VM RMS Stack
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-vm-stack
+      #   continue-on-error: true
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
   smoke-test-bm:
+    needs: [smoke-test-vm]
     runs-on: ubuntu-latest
     name: Create BM cluster infrastructure
     env:
@@ -75,8 +90,8 @@ jobs:
       COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
       ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
       CLUSTER_NAME: smoke-test-bm
-    outputs:
-      stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
+    # outputs:
+    #   stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -102,12 +117,12 @@ jobs:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"control_plane_shape\": \"BM.Standard3.64\", \"control_plane_ocpu\": \"64\", \"control_plane_memory\": \"1024\", \"compute_shape\": \"BM.Standard3.64\", \"compute_ocpu\": \"64\", \"compute_memory\": \"1024\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
-      - name: Output Stack ID
-        id: output-stack-id
-        env:
-          stack_id: ${{ steps.create-stack.outputs.raw_output }}
-        run: |
-          echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
+      # - name: Output Stack ID
+      #   id: output-stack-id
+      #   env:
+      #     stack_id: ${{ steps.create-stack.outputs.raw_output }}
+      #   run: |
+      #     echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: RMS Stack Plan Job
         uses: oracle-actions/run-oci-cli-command@v1.3.1
@@ -120,8 +135,22 @@ jobs:
         id: stack-apply-job
         with:
           command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+      
+      - name: Teardown BM Infrastructure
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: teardown-bm-infra
+        with:
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      # - name: Destroy BM RMS Stack
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-bm-stack
+      #   continue-on-error: true
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
   smoke-test-vm-multi-ad:
+    needs: [smoke-test-bm]
     runs-on: ubuntu-latest
     name: Create VM cluster infrastructure in multi-ad region
     env:
@@ -135,8 +164,8 @@ jobs:
       ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
       CLUSTER_NAME: smoke-test-vm-multi-ad
       MUTLI_AD_REGION: eu-frankfurt-1
-    outputs:
-      stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
+    # outputs:
+    #   stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -162,12 +191,12 @@ jobs:
           command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.MUTLI_AD_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
           query: 'data.id'
 
-      - name: Output Stack ID
-        id: output-stack-id
-        env:
-          stack_id: ${{ steps.create-stack.outputs.raw_output }}
-        run: |
-          echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
+      # - name: Output Stack ID
+      #   id: output-stack-id
+      #   env:
+      #     stack_id: ${{ steps.create-stack.outputs.raw_output }}
+      #   run: |
+      #     echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: RMS Stack Plan Job
         uses: oracle-actions/run-oci-cli-command@v1.3.1
@@ -181,59 +210,72 @@ jobs:
         with:
           command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
-  teardown-stacks:
-    if: ${{ !cancelled() }}
-    needs: [smoke-test-vm, smoke-test-bm, smoke-test-vm-multi-ad]
-    runs-on: ubuntu-latest
-    name: Teardown cluster infrastructure
-    env:
-      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
-      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
-      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
-      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
-      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
-    steps:
-      - name: Teardown VM Infrastructure
-        if: ${{ needs.smoke-test-vm.result == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: teardown-vm-infra
-        with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
-
-      - name: Teardown BM Infrastructure
-        if: ${{ needs.smoke-test-bm.result == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: teardown-bm-infra
-        with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
-
-      - name: Teardown VM multi-ad Infrastructure
-        if: ${{ needs.smoke-test-vm-multi-ad.result == 'success' }}
+      - name: Teardown VM Multi AD Infrastructure
         uses: oracle-actions/run-oci-cli-command@v1.3.1
         id: teardown-vm-multi-ad-infra
         with:
-          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
-      - name: Destroy VM RMS Stack
-        if: ${{ steps.teardown-vm-infra.outcome == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: destroy-vm-stack
-        continue-on-error: true
-        with:
-          command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
+      # - name: Destroy VM Multi AD RMS Stack
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-vm-multi-ad-stack
+      #   continue-on-error: true
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ steps.create-stack.outputs.raw_output }}'
 
-      - name: Destroy BM RMS Stack
-        if: ${{ steps.teardown-bm-infra.outcome == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: destroy-bm-stack
-        continue-on-error: true
-        with:
-          command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
+  # teardown-stacks:
+  #   if: ${{ !cancelled() }}
+  #   needs: [smoke-test-vm, smoke-test-bm, smoke-test-vm-multi-ad]
+    # runs-on: ubuntu-latest
+    # name: Teardown cluster infrastructure
+    # env:
+    #   OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+    #   OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+    #   OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+    #   OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+    #   OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+    # steps:
+    #   - name: Teardown VM Infrastructure
+    #     if: ${{ needs.smoke-test-vm.result == 'success' }}
+    #     uses: oracle-actions/run-oci-cli-command@v1.3.1
+    #     id: teardown-vm-infra
+    #     with:
+    #       command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
 
-      - name: Destroy VM multi-ad RMS Stack
-        if: ${{ steps.teardown-vm-multi-ad-infra.outcome == 'success' }}
-        uses: oracle-actions/run-oci-cli-command@v1.3.1
-        id: destroy-vm-multi-ad-stack
-        continue-on-error: true
-        with:
-          command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
+    #   - name: Teardown BM Infrastructure
+      #   if: ${{ needs.smoke-test-bm.result == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: teardown-bm-infra
+      #   with:
+      #     command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
+
+      # - name: Teardown VM multi-ad Infrastructure
+      #   if: ${{ needs.smoke-test-vm-multi-ad.result == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: teardown-vm-multi-ad-infra
+      #   with:
+      #     command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
+
+      # - name: Destroy VM RMS Stack
+      #   if: ${{ steps.teardown-vm-infra.outcome == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-vm-stack
+      #   continue-on-error: true
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
+
+      # - name: Destroy BM RMS Stack
+      #   if: ${{ steps.teardown-bm-infra.outcome == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-bm-stack
+      #   continue-on-error: true
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
+
+      # - name: Destroy VM multi-ad RMS Stack
+      #   if: ${{ steps.teardown-vm-multi-ad-infra.outcome == 'success' }}
+      #   uses: oracle-actions/run-oci-cli-command@v1.3.1
+      #   id: destroy-vm-multi-ad-stack
+      #   continue-on-error: true
+      #   with:
+      #     command: 'resource-manager stack delete --force --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,236 @@
+name: Infrastructure Smoke Test
+on:
+  schedule:
+    - cron: "20 5 */2 * *"
+jobs:
+  smoke-test-vm:
+    runs-on: ubuntu-latest
+    name: Create VM cluster infrastructure
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+      OPENSHIFT_IMAGE_SOURCE_URI: ${{ secrets.OPENSHIFT_IMAGE_SOURCE_URI }}
+      COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
+      ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
+      CLUSTER_NAME: smoke-test-vm
+    outputs:
+      stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set NOW env variable
+        run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
+      - name: Create Terraform ZIP
+        run: |
+          if [ -f infrastructure.tf ]; then
+            zip infrastructure.zip infrastructure.tf
+          elif [ -d infrastructure ]; then
+            zip -j infrastructure.zip infrastructure/data.tf infrastructure/locals.tf infrastructure/main.tf infrastructure/output.tf infrastructure/schema.yaml infrastructure/variables.tf
+          else
+            echo "Could not find infrastructure.tf or infrastructure directory"
+            exit 1
+          fi
+
+      - name: Create RMS Stack
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: create-stack
+        with:
+          command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
+          query: 'data.id'
+      
+      - name: Output Stack ID
+        id: output-stack-id
+        env:
+          stack_id: ${{ steps.create-stack.outputs.raw_output }}
+        run: |
+          echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
+
+      - name: RMS Stack Plan Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-plan-job
+        with:
+          command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      - name: RMS Stack Apply Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-apply-job
+        with:
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+  smoke-test-bm:
+    runs-on: ubuntu-latest
+    name: Create BM cluster infrastructure
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+      OPENSHIFT_IMAGE_SOURCE_URI: ${{ secrets.OPENSHIFT_IMAGE_SOURCE_URI }}
+      COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
+      ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
+      CLUSTER_NAME: smoke-test-bm
+    outputs:
+      stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set NOW env variable
+        run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
+      - name: Create Terraform ZIP
+        run: |
+          if [ -f infrastructure.tf ]; then
+            zip infrastructure.zip infrastructure.tf
+          elif [ -d infrastructure ]; then
+            zip -j infrastructure.zip infrastructure/data.tf infrastructure/locals.tf infrastructure/main.tf infrastructure/output.tf infrastructure/schema.yaml infrastructure/variables.tf
+          else
+            echo "Could not find infrastructure.tf or infrastructure directory"
+            exit 1
+          fi
+
+      - name: Create RMS Stack
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: create-stack
+        with:
+          command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"control_plane_shape\": \"BM.Standard3.64\", \"control_plane_ocpu\": \"64\", \"control_plane_memory\": \"1024\", \"compute_shape\": \"BM.Standard3.64\", \"compute_ocpu\": \"64\", \"compute_memory\": \"1024\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.OCI_CLI_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
+          query: 'data.id'
+
+      - name: Output Stack ID
+        id: output-stack-id
+        env:
+          stack_id: ${{ steps.create-stack.outputs.raw_output }}
+        run: |
+          echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
+
+      - name: RMS Stack Plan Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-plan-job
+        with:
+          command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      - name: RMS Stack Apply Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-apply-job
+        with:
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+  smoke-test-vm-multi-ad:
+    runs-on: ubuntu-latest
+    name: Create VM cluster infrastructure in multi-ad region
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+      OPENSHIFT_IMAGE_SOURCE_URI: ${{ secrets.OPENSHIFT_IMAGE_SOURCE_URI }}
+      COMPARTMENT_OCID: ${{ secrets.COMPARTMENT_OCID }}
+      ZONE_DNS_SUFFIX: ${{ secrets.ZONE_DNS_SUFFIX }}
+      CLUSTER_NAME: smoke-test-vm-multi-ad
+      MUTLI_AD_REGION: eu-frankfurt-1
+    outputs:
+      stack_id: ${{ steps.output-stack-id.outputs.stack_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set NOW env variable
+        run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
+      - name: Create Terraform ZIP
+        run: |
+          if [ -f infrastructure.tf ]; then
+            zip infrastructure.zip infrastructure.tf
+          elif [ -d infrastructure ]; then
+            zip -j infrastructure.zip infrastructure/data.tf infrastructure/locals.tf infrastructure/main.tf infrastructure/output.tf infrastructure/schema.yaml infrastructure/variables.tf
+          else
+            echo "Could not find infrastructure.tf or infrastructure directory"
+            exit 1
+          fi
+
+      - name: Create RMS Stack
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: create-stack
+        with:
+          command: 'resource-manager stack create --compartment-id ${{ env.COMPARTMENT_OCID }} --display-name ${{ github.job }}-${{ env.NOW }} --config-source infrastructure.zip --variables "{\"compartment_ocid\": \"${{ env.COMPARTMENT_OCID }}\", \"cluster_name\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}\", \"openshift_image_source_uri\": \"${{ env.OPENSHIFT_IMAGE_SOURCE_URI }}\", \"region\": \"${{ env.MUTLI_AD_REGION }}\", \"tenancy_ocid\": \"${{ env.OCI_CLI_TENANCY }}\", \"zone_dns\": \"${{ env.CLUSTER_NAME }}-${{ env.NOW }}${{ env.ZONE_DNS_SUFFIX }}\"}"'
+          query: 'data.id'
+
+      - name: Output Stack ID
+        id: output-stack-id
+        env:
+          stack_id: ${{ steps.create-stack.outputs.raw_output }}
+        run: |
+          echo "stack_id=$(echo $stack_id | tr -d '"')" >> $GITHUB_OUTPUT
+
+      - name: RMS Stack Plan Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-plan-job
+        with:
+          command: 'resource-manager job create-plan-job --wait-for-state SUCCEEDED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+      - name: RMS Stack Apply Job
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: stack-apply-job
+        with:
+          command: 'resource-manager job create-apply-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ steps.create-stack.outputs.raw_output }}'
+
+  teardown-stacks:
+    if: ${{ !cancelled() }}
+    needs: [smoke-test-vm, smoke-test-bm, smoke-test-vm-multi-ad]
+    runs-on: ubuntu-latest
+    name: Teardown cluster infrastructure
+    env:
+      OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+      OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+      OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+      OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+      OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
+    steps:
+      - name: Teardown VM Infrastructure
+        if: ${{ needs.smoke-test-vm.result == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: teardown-vm-infra
+        with:
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
+      
+      - name: Teardown BM Infrastructure
+        if: ${{ needs.smoke-test-bm.result == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: teardown-bm-infra
+        with:
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
+      
+      - name: Teardown VM multi-ad Infrastructure
+        if: ${{ needs.smoke-test-vm-multi-ad.result == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: teardown-vm-multi-ad-infra
+        with:
+          command: 'resource-manager job create-destroy-job --wait-for-state SUCCEEDED --max-wait-seconds 1800 --execution-plan-strategy AUTO_APPROVED --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'
+
+      - name: Destroy VM RMS Stack
+        if: ${{ needs.smoke-test-vm.result == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: destroy-vm-stack
+        with:
+          command: 'resource-manager stack destroy --stack-id ${{ needs.smoke-test-vm.outputs.stack_id }}'
+
+      - name: Destroy BM RMS Stack
+        if: ${{ needs.smoke-test-bm.result == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: destroy-bm-stack
+        with:
+          command: 'resource-manager stack destroy --stack-id ${{ needs.smoke-test-bm.outputs.stack_id }}'
+     
+      - name: Destroy VM multi-ad RMS Stack
+        if: ${{ needs.smoke-test-vm-multi-ad.result == 'success' }}
+        uses: oracle-actions/run-oci-cli-command@v1.3.1
+        id: destroy-vm-multi-ad-stack
+        with:
+          command: 'resource-manager stack destroy --stack-id ${{ needs.smoke-test-vm-multi-ad.outputs.stack_id }}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/
 .DS_Store
+.dev
+.secrets
 
 ### Terraform ###
 # Local .terraform directories


### PR DESCRIPTION
### Description
Includes 2 workflows for testing the process of creating infrastructure on OCI used for OpenShift cluster as specified in our Terraform files. 

`change-test.yml` is triggered by pull requests to main to verify there are no breaking changes. It creates and destroys one set of cluster infrastructure using VMs and default settings.

`smoke-test.yml` is scheduled to run every 2 days early in the day (UTC) to test for any sneaky issues or changes not due to an immediate Terraform change. It creates and destroys 2 sets of cluster infrastructure:
1. BMs with default settings in us-sanjose-1 (single-AD)
2. VMs with default settings in eu-frankfurt-1 (multi-AD)

### Motivation
Testing changes automatically is important. Periodically testing to detect changes outside of our Terraform is important. It's all in the name of ensuring quality and to prevent faulty code from making it to customers.

### Testing
Tested both workflows locally via `act`. Both workflows ran successfully from within repository.
[
![Screenshot 2024-09-06 at 12 56 35 PM](https://github.com/user-attachments/assets/57a3f719-00f8-4e17-83d8-754e8e6092eb)
](url)
![Screenshot 2024-09-06 at 12 56 25 PM](https://github.com/user-attachments/assets/420ec605-917d-4e14-89c2-60e85ed0cd07)

Scheduled smoke tests all succeeded except for an instance where multi-ad took longer than 30 minutes to complete, but it did complete shortly afterwards. Extending the step timeouts to 40 minutes which should allow them to be aware of the success.
![Screenshot 2024-09-16 at 10 12 30 AM](https://github.com/user-attachments/assets/6aae1c87-a719-4a09-850b-f1ba619d7b48)

