### PR TITLE
fix: support using existing dns_zone

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -613,6 +613,7 @@ resource "oci_dns_zone" "openshift" {
   name           = var.zone_dns
   scope          = var.enable_private_dns ? "PRIVATE" : null
   view_id        = var.enable_private_dns ? data.oci_dns_resolver.dns_resolver.default_view_id : null
+  count          = var.use_existing_zone ? 0 : 1
   zone_type      = "PRIMARY"
   depends_on     = [oci_core_subnet.private]
 }
@@ -626,7 +627,7 @@ resource "oci_dns_rrset" "openshift_api" {
     ttl    = "3600"
   }
   rtype           = "A"
-  zone_name_or_id = oci_dns_zone.openshift.id
+  zone_name_or_id = var.use_existing_zone ? var.zone_dns : oci_dns_zone.openshift[0].id
 }
 
 resource "oci_dns_rrset" "openshift_apps" {
@@ -638,7 +639,7 @@ resource "oci_dns_rrset" "openshift_apps" {
     ttl    = "3600"
   }
   rtype           = "A"
-  zone_name_or_id = oci_dns_zone.openshift.id
+  zone_name_or_id = var.use_existing_zone ? var.zone_dns : oci_dns_zone.openshift[0].id
 }
 
 resource "oci_dns_rrset" "openshift_api_int" {
@@ -650,7 +651,7 @@ resource "oci_dns_rrset" "openshift_api_int" {
     ttl    = "3600"
   }
   rtype           = "A"
-  zone_name_or_id = oci_dns_zone.openshift.id
+  zone_name_or_id = var.use_existing_zone ? var.zone_dns : oci_dns_zone.openshift[0].id
 }
 
 resource "time_sleep" "wait_180_seconds" {

--- a/infrastructure/schema.yaml
+++ b/infrastructure/schema.yaml
@@ -40,6 +40,7 @@ variableGroups:
 - title: "Networking Configuration"
   variables:
     - enable_private_dns
+    - use_existing_zone
     - zone_dns
     - vcn_dns_label
     - vcn_cidr
@@ -207,6 +208,12 @@ variables:
     type: boolean
     title: Enable Private DNS
     description: If the switch is enabled, a private DNS zone will be created, and users should edit the /etc/hosts file for resolution. Otherwise, a public DNS zone will be created based on the given domain.
+    default: false
+
+  use_existing_zone:
+    type: boolean
+    title: Use Existing DNS Zone name
+    description: If the switch is enabled, an existing DNS zone will be used instead of creating a new one.
     default: false
 
   zone_dns:

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -199,6 +199,12 @@ variable "enable_private_dns" {
   default     = false
 }
 
+variable "use_existing_zone" {
+  type        = bool
+  description = "When set, an existing DNS zone will be used instead of creating a new one."
+  default     = false
+}
+
 variable "create_openshift_instances" {
   type    = bool
   default = true


### PR DESCRIPTION
### Description

This change introduces a flag to use existing DNS Zone when it already exists, preventing errors on terraform when the user specified an domain in BaseDomain (Assisted Installer) which has been created, or is already used by the company.

The script will follow the same flow, but reuse existing zone to create cluster DNS records.

### Motivation

Feature to prevent failures when deploying the Stack when the customer has already an zone defined on "BaseDomain", common use case.

### Testing
< If you haven't already, [install](https://pre-commit.com/#install) and [use](https://pre-commit.com/#usage) `pre-commit` >

< Provide proof of testing the changes (screenshots, output, etc) >
