### PR TITLE
Customize network configuration to install OCP 4.17

### DIFF
--- a/custom_manifests/manifests/cluster-network-03-config.yml
+++ b/custom_manifests/manifests/cluster-network-03-config.yml
@@ -1,0 +1,12 @@
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      gatewayConfig:
+        ipv4:
+          internalMasqueradeSubnet: 169.254.64.0/18
+    type: OVNKubernetes
+  managementState: Managed


### PR DESCRIPTION
From OCP 4.17 the network operator will use the range 169.254.0.0/17 for
the `internalMasqueradeSubnet` (https://docs.openshift.com/container-platform/4.16/networking/cluster-network-operator.html#nw-operator-cr-cno-object_cluster-network-operator).

This default value collides with the iSCSI subnet used in OCI, and
prevent the installation of OCP on nodes with iSCSI boot drives.

This commit updates the default value of `internalMasqueradeSubnet` to
use a range that doesn't collide to anything [known to me] in Oracle
Cloud.
