### PR TITLE
OSO-192 | Modified | Logic to distribute nodes across fault domains

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -9,6 +9,12 @@ data "oci_identity_availability_domains" "ads" {
   compartment_id = var.compartment_ocid
 }
 
+data "oci_identity_fault_domains" "fds" {
+  for_each            = toset([for ad in local.availability_domains : ad.name])
+  availability_domain = each.value
+  compartment_id      = var.compartment_ocid
+}
+
 data "oci_core_compute_global_image_capability_schemas" "image_capability_schemas" {
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -709,6 +709,7 @@ resource "oci_core_instance" "control_plane_node" {
   for_each            = var.create_openshift_instances ? local.cp_node_map : {}
   compartment_id      = var.compartment_ocid
   availability_domain = each.value.ad_name
+  fault_domain        = each.value.fault_domain
   display_name        = "${var.cluster_name}-cp-${each.value.index}-ad${regex("\\d+$", each.value.ad_name)}"
   shape               = var.control_plane_shape
   defined_tags = {
@@ -745,6 +746,7 @@ resource "oci_core_instance" "compute_node" {
   for_each            = var.create_openshift_instances ? local.compute_node_map : {}
   compartment_id      = var.compartment_ocid
   availability_domain = each.value.ad_name
+  fault_domain        = each.value.fault_domain
   display_name        = "${var.cluster_name}-compute-${each.value.index}-ad${regex("\\d+$", each.value.ad_name)}"
   shape               = var.compute_shape
   defined_tags = {

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -23,20 +23,3 @@ rateLimiter:
   rateLimitBucketWrite: 5
   OCICCMCONFIG
 }
-
-locals {
-  x = local.compute_node_count_per_ad_flattened
-  y = local.cp_node_count_per_ad_flattened
-  z = local.compute_node_map
-  c = local.cp_node_map
-}
-
-output "ad-fd-distro" {
-  value = {
-    a = local.compute_node_count_per_ad_flattened
-    b = local.cp_node_count_per_ad_flattened
-    c = local.compute_node_map
-    d = local.cp_node_map
-  }
-}
-

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -23,3 +23,20 @@ rateLimiter:
   rateLimitBucketWrite: 5
   OCICCMCONFIG
 }
+
+locals {
+  x = local.compute_node_count_per_ad_flattened
+  y = local.cp_node_count_per_ad_flattened
+  z = local.compute_node_map
+  c = local.cp_node_map
+}
+
+output "ad-fd-distro" {
+  value = {
+    a = local.compute_node_count_per_ad_flattened
+    b = local.cp_node_count_per_ad_flattened
+    c = local.compute_node_map
+    d = local.cp_node_map
+  }
+}
+


### PR DESCRIPTION
### Description
Nodes were not being distributed across fault domains as expected. Previously, this was managed through instance pools and configurations. However, since we've moved away from using them, we now need to implement logic to handle fault domain distribution for both control plane and compute nodes.

### Motivation
Cluster availability will not be compromised if nodes get distributed across fault domains.

### Testing

For single AD region
![Screenshot 2024-10-10 at 12 10 27 PM](https://github.com/user-attachments/assets/012c9b84-b598-4fd5-b0e4-9ceae3699a4c)

For Multi AD region
![Screenshot 2024-10-11 at 11 12 29 AM](https://github.com/user-attachments/assets/6dcb9c15-cd25-4fb8-a8a7-d0ad9216b97c)

Host discovery is successful on the console
![Screenshot 2024-10-11 at 11 14 29 AM](https://github.com/user-attachments/assets/d30980b2-3ce8-4aca-8cd2-184a2969ca88)

RMS apply job was successful as well
<img width="1512" alt="Screenshot 2024-10-11 at 11 23 23 AM" src="https://github.com/user-attachments/assets/9d4f8a0e-7f12-42cc-9926-f4b82bf272a3">




