### PR TITLE
release-v1.1.0 minor fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL = bash
 PKG_VERSION ?= v1.1.0
+OCI_DRIVER_VERSION ?= v1.30.0
 PRE_COMMIT := $(shell command -v pre-commit 2> /dev/null)
 PODMAN := $(shell command -v podman 2> /dev/null)
 OC := $(shell command -v oc 2> /dev/null)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [✓] Bug Fix

## Summary

During the release of V1.1.0 we accidentally removed the `OCI_DRIVER_VERSION` which cause the driver version upgrades to fail. So we are pushing this change to fix the issue. 

## Description of Changes

During the release of V1.1.0 we accidentally removed the `OCI_DRIVER_VERSION` which cause the driver version upgrades to fail. So we are pushing this change to fix the issue. 

## Related Tickets & Documents
- Related Issue #
  - N/A
- Closes 
   - N/A

## Testing

Tested locally

## Checklist

- [ ✓] Ran `make` (with [pre-commit](https://pre-commit.com/#usage) installed)
- [ ✓] Tested and added to automated tests (if applicable)
- [ ✓] Documentation updated (READMEs, public, internal)

## Notes & Other Considerations
N/A