### PR TITLE
Updated to create separate LoadBalancer for *.apps (ingress)

### DIFF
--- a/terraform-stacks/add-nodes/data.tf
+++ b/terraform-stacks/add-nodes/data.tf
@@ -9,9 +9,14 @@ data "oci_identity_tag_namespaces" "openshift_tag_namespace" {
   }
 }
 
-data "oci_load_balancer_load_balancers" "openshift_api_apps_lb" {
+data "oci_load_balancer_load_balancers" "openshift_api_lb" {
   compartment_id = var.compartment_ocid
-  display_name   = "${var.cluster_name}-openshift_api_apps_lb"
+  display_name   = "${var.cluster_name}-openshift_api_lb"
+}
+
+data "oci_load_balancer_load_balancers" "openshift_apps_lb" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.cluster_name}-openshift_apps_lb"
 }
 
 data "oci_load_balancer_load_balancers" "openshift_api_int_lb" {
@@ -19,14 +24,14 @@ data "oci_load_balancer_load_balancers" "openshift_api_int_lb" {
   display_name   = "${var.cluster_name}-openshift_api_int_lb"
 }
 
-data "oci_load_balancer_backends" "openshift_api_apps_api_backend" {
+data "oci_load_balancer_backends" "openshift_api_backend" {
   backendset_name  = "openshift_cluster_api_backend"
-  load_balancer_id = data.oci_load_balancer_load_balancers.openshift_api_apps_lb.load_balancers[0].id
+  load_balancer_id = data.oci_load_balancer_load_balancers.openshift_api_lb.load_balancers[0].id
 }
 
-data "oci_load_balancer_backends" "openshift_api_apps_ingress_http" {
+data "oci_load_balancer_backends" "openshift_apps_ingress_http" {
   backendset_name  = "openshift_cluster_ingress_http"
-  load_balancer_id = data.oci_load_balancer_load_balancers.openshift_api_apps_lb.load_balancers[0].id
+  load_balancer_id = data.oci_load_balancer_load_balancers.openshift_apps_lb.load_balancers[0].id
 }
 
 data "oci_core_vcns" "cluster_vcn" {

--- a/terraform-stacks/add-nodes/locals.tf
+++ b/terraform-stacks/add-nodes/locals.tf
@@ -16,8 +16,8 @@ locals {
   is_control_plane_iscsi_type = can(regex("^BM\\..*$", var.control_plane_shape))
   is_compute_iscsi_type       = can(regex("^BM\\..*$", var.compute_shape))
 
-  current_cp_count      = length(data.oci_load_balancer_backends.openshift_api_apps_api_backend.backends)
-  current_compute_count = length(data.oci_load_balancer_backends.openshift_api_apps_ingress_http.backends) - local.current_cp_count
+  current_cp_count      = length(data.oci_load_balancer_backends.openshift_api_backend.backends)
+  current_compute_count = length(data.oci_load_balancer_backends.openshift_apps_ingress_http.backends) - local.current_cp_count
 
   day_2_image_name = format("%s-day-2", var.cluster_name)
 

--- a/terraform-stacks/add-nodes/main.tf
+++ b/terraform-stacks/add-nodes/main.tf
@@ -104,7 +104,8 @@ module "compute" {
 
   // Depedency on loadbalancer
   op_lb_openshift_api_int_lb                           = data.oci_load_balancer_load_balancers.openshift_api_int_lb.load_balancers[0].id
-  op_lb_openshift_api_apps_lb                          = data.oci_load_balancer_load_balancers.openshift_api_apps_lb.load_balancers[0].id
+  op_lb_openshift_api_lb                               = data.oci_load_balancer_load_balancers.openshift_api_lb.load_balancers[0].id
+  op_lb_openshift_apps_lb                               = data.oci_load_balancer_load_balancers.openshift_apps_lb.load_balancers[0].id
   op_lb_bs_openshift_cluster_api_backend_set_external  = "openshift_cluster_api_backend"
   op_lb_bs_openshift_cluster_ingress_http_backend_set  = "openshift_cluster_ingress_http"
   op_lb_bs_openshift_cluster_ingress_https_backend_set = "openshift_cluster_ingress_https"

--- a/terraform-stacks/create-cluster/main.tf
+++ b/terraform-stacks/create-cluster/main.tf
@@ -163,7 +163,8 @@ module "compute" {
 
   // Depedency on loadbalancer
   op_lb_openshift_api_int_lb                           = module.load_balancer.op_lb_openshift_api_int_lb
-  op_lb_openshift_api_apps_lb                          = module.load_balancer.op_lb_openshift_api_apps_lb
+  op_lb_openshift_api_lb                               = module.load_balancer.op_lb_openshift_api_lb
+  op_lb_openshift_apps_lb                              = module.load_balancer.op_lb_openshift_apps_lb
   op_lb_bs_openshift_cluster_api_backend_set_external  = module.load_balancer.op_lb_bs_openshift_cluster_api_backend_set_external
   op_lb_bs_openshift_cluster_ingress_http_backend_set  = module.load_balancer.op_lb_bs_openshift_cluster_ingress_http_backend_set
   op_lb_bs_openshift_cluster_ingress_https_backend_set = module.load_balancer.op_lb_bs_openshift_cluster_ingress_https_backend_set
@@ -187,7 +188,8 @@ module "dns" {
 
   // Depedency on load balancer
   op_lb_openshift_api_int_lb_ip_addr  = module.load_balancer.op_lb_openshift_api_int_lb_ip_addr
-  op_lb_openshift_api_apps_lb_ip_addr = module.load_balancer.op_lb_openshift_api_apps_lb_ip_addr
+  op_lb_openshift_api_lb_ip_addr = module.load_balancer.op_lb_openshift_api_lb_ip_addr
+  op_lb_openshift_apps_lb_ip_addr = module.load_balancer.op_lb_openshift_apps_lb_ip_addr
 
   // Depedency on networks
   op_vcn_openshift_vcn = module.network.op_vcn_openshift_vcn

--- a/terraform-stacks/create-cluster/output.tf
+++ b/terraform-stacks/create-cluster/output.tf
@@ -2,8 +2,12 @@ output "open_shift_api_int_lb_addr" {
   value = module.load_balancer.op_lb_openshift_api_int_lb_ip_addr
 }
 
-output "open_shift_api_apps_lb_addr" {
-  value = module.load_balancer.op_lb_openshift_api_apps_lb_ip_addr
+output "open_shift_api_lb_addr" {
+  value = module.load_balancer.op_lb_openshift_api_lb_ip_addr
+}
+
+output "open_shift_apps_lb_addr" {
+  value = module.load_balancer.op_lb_openshift_apps_lb_ip_addr
 }
 
 output "oci_ccm_config" {

--- a/terraform-stacks/shared_modules/compute/backends.tf
+++ b/terraform-stacks/shared_modules/compute/backends.tf
@@ -3,7 +3,7 @@
 
 resource "oci_load_balancer_backend" "openshift_cluster_api_backend_set_external_backends" {
   for_each         = var.create_openshift_instances ? var.cp_node_map : {}
-  load_balancer_id = var.op_lb_openshift_api_apps_lb
+  load_balancer_id = var.op_lb_openshift_api_lb
   backendset_name  = var.op_lb_bs_openshift_cluster_api_backend_set_external
   port             = 6443
   ip_address       = var.is_control_plane_iscsi_type ? data.oci_core_vnic.control_plane_secondary_vnic[each.key].private_ip_address : data.oci_core_vnic.control_plane_primary_vnic[each.key].private_ip_address
@@ -11,7 +11,7 @@ resource "oci_load_balancer_backend" "openshift_cluster_api_backend_set_external
 
 resource "oci_load_balancer_backend" "openshift_cp_cluster_ingress_https_backend_set_backends" {
   for_each         = var.create_openshift_instances ? var.cp_node_map : {}
-  load_balancer_id = var.op_lb_openshift_api_apps_lb
+  load_balancer_id = var.op_lb_openshift_apps_lb
   backendset_name  = var.op_lb_bs_openshift_cluster_ingress_https_backend_set
   port             = 443
   ip_address       = var.is_control_plane_iscsi_type ? data.oci_core_vnic.control_plane_secondary_vnic[each.key].private_ip_address : data.oci_core_vnic.control_plane_primary_vnic[each.key].private_ip_address
@@ -19,7 +19,7 @@ resource "oci_load_balancer_backend" "openshift_cp_cluster_ingress_https_backend
 
 resource "oci_load_balancer_backend" "openshift_cp_cluster_ingress_http_backend_set_backends" {
   for_each         = var.create_openshift_instances ? var.cp_node_map : {}
-  load_balancer_id = var.op_lb_openshift_api_apps_lb
+  load_balancer_id = var.op_lb_openshift_apps_lb
   backendset_name  = var.op_lb_bs_openshift_cluster_ingress_http_backend_set
   port             = 80
   ip_address       = var.is_control_plane_iscsi_type ? data.oci_core_vnic.control_plane_secondary_vnic[each.key].private_ip_address : data.oci_core_vnic.control_plane_primary_vnic[each.key].private_ip_address
@@ -51,7 +51,7 @@ resource "oci_load_balancer_backend" "openshift_cluster_infra-mcs_backend_set_2_
 
 resource "oci_load_balancer_backend" "openshift_cluster_ingress_https_backend_set_backends" {
   for_each         = var.create_openshift_instances ? var.compute_node_map : {}
-  load_balancer_id = var.op_lb_openshift_api_apps_lb
+  load_balancer_id = var.op_lb_openshift_apps_lb
   backendset_name  = var.op_lb_bs_openshift_cluster_ingress_https_backend_set
   port             = 443
   ip_address       = var.is_compute_iscsi_type ? data.oci_core_vnic.compute_secondary_vnic[each.key].private_ip_address : data.oci_core_vnic.compute_primary_vnic[each.key].private_ip_address
@@ -59,7 +59,7 @@ resource "oci_load_balancer_backend" "openshift_cluster_ingress_https_backend_se
 
 resource "oci_load_balancer_backend" "openshift_cluster_ingress_http_backend_set_backends" {
   for_each         = var.create_openshift_instances ? var.compute_node_map : {}
-  load_balancer_id = var.op_lb_openshift_api_apps_lb
+  load_balancer_id = var.op_lb_openshift_apps_lb
   backendset_name  = var.op_lb_bs_openshift_cluster_ingress_http_backend_set
   port             = 80
   ip_address       = var.is_compute_iscsi_type ? data.oci_core_vnic.compute_secondary_vnic[each.key].private_ip_address : data.oci_core_vnic.compute_primary_vnic[each.key].private_ip_address

--- a/terraform-stacks/shared_modules/compute/variables.tf
+++ b/terraform-stacks/shared_modules/compute/variables.tf
@@ -98,7 +98,11 @@ variable "op_lb_openshift_api_int_lb" {
   type = string
 }
 
-variable "op_lb_openshift_api_apps_lb" {
+variable "op_lb_openshift_api_lb" {
+  type = string
+}
+
+variable "op_lb_openshift_apps_lb" {
   type = string
 }
 

--- a/terraform-stacks/shared_modules/dns/main.tf
+++ b/terraform-stacks/shared_modules/dns/main.tf
@@ -15,14 +15,14 @@ resource "oci_dns_zone" "openshift" {
   view_id        = var.enable_private_dns ? data.oci_dns_resolver.dns_resolver.default_view_id : null
   zone_type      = "PRIMARY"
   defined_tags   = var.defined_tags
-  depends_on     = [var.op_lb_openshift_api_apps_lb_ip_addr, var.op_lb_openshift_api_int_lb_ip_addr]
+  depends_on     = [var.op_lb_openshift_api_lb_ip_addr, var.op_lb_openshift_apps_lb_ip_addr, var.op_lb_openshift_api_int_lb_ip_addr]
 }
 
 resource "oci_dns_rrset" "openshift_api" {
   domain = "api.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "api.${var.cluster_name}.${var.zone_dns}"
-    rdata  = var.op_lb_openshift_api_apps_lb_ip_addr
+    rdata  = var.op_lb_openshift_api_lb_ip_addr
     rtype  = "A"
     ttl    = "3600"
   }
@@ -34,7 +34,7 @@ resource "oci_dns_rrset" "openshift_apps" {
   domain = "*.apps.${var.cluster_name}.${var.zone_dns}"
   items {
     domain = "*.apps.${var.cluster_name}.${var.zone_dns}"
-    rdata  = var.op_lb_openshift_api_apps_lb_ip_addr
+    rdata  = var.op_lb_openshift_apps_lb_ip_addr
     rtype  = "A"
     ttl    = "3600"
   }

--- a/terraform-stacks/shared_modules/dns/variables.tf
+++ b/terraform-stacks/shared_modules/dns/variables.tf
@@ -22,7 +22,11 @@ variable "op_lb_openshift_api_int_lb_ip_addr" {
   type = string
 }
 
-variable "op_lb_openshift_api_apps_lb_ip_addr" {
+variable "op_lb_openshift_api_lb_ip_addr" {
+  type = string
+}
+
+variable "op_lb_openshift_apps_lb_ip_addr" {
   type = string
 }
 

--- a/terraform-stacks/shared_modules/lb/lb-backend.tf
+++ b/terraform-stacks/shared_modules/lb/lb-backend.tf
@@ -9,14 +9,14 @@ resource "oci_load_balancer_backend_set" "openshift_cluster_api_backend_set_exte
     retries           = 3
   }
   name             = "openshift_cluster_api_backend"
-  load_balancer_id = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_api_lb.id
   policy           = "LEAST_CONNECTIONS"
 }
 
 resource "oci_load_balancer_listener" "openshift_cluster_api_listener_external" {
   default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_api_backend_set_external.name
   name                     = "openshift_cluster_api_listener"
-  load_balancer_id         = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_api_lb.id
   port                     = 6443
   protocol                 = "TCP"
 }
@@ -30,14 +30,14 @@ resource "oci_load_balancer_backend_set" "openshift_cluster_ingress_http_backend
     retries           = 3
   }
   name             = "openshift_cluster_ingress_http"
-  load_balancer_id = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_apps_lb.id
   policy           = "LEAST_CONNECTIONS"
 }
 
 resource "oci_load_balancer_listener" "openshift_cluster_ingress_http" {
   default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_http_backend_set.name
   name                     = "openshift_cluster_ingress_http"
-  load_balancer_id         = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_apps_lb.id
   port                     = 80
   protocol                 = "TCP"
 }
@@ -51,14 +51,14 @@ resource "oci_load_balancer_backend_set" "openshift_cluster_ingress_https_backen
     retries           = 3
   }
   name             = "openshift_cluster_ingress_https"
-  load_balancer_id = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+  load_balancer_id = oci_load_balancer_load_balancer.openshift_apps_lb.id
   policy           = "LEAST_CONNECTIONS"
 }
 
 resource "oci_load_balancer_listener" "openshift_cluster_ingress_https" {
   default_backend_set_name = oci_load_balancer_backend_set.openshift_cluster_ingress_https_backend_set.name
   name                     = "openshift_cluster_ingress_https"
-  load_balancer_id         = oci_load_balancer_load_balancer.openshift_api_apps_lb.id
+  load_balancer_id         = oci_load_balancer_load_balancer.openshift_apps_lb.id
   port                     = 443
   protocol                 = "TCP"
 }

--- a/terraform-stacks/shared_modules/lb/main.tf
+++ b/terraform-stacks/shared_modules/lb/main.tf
@@ -22,9 +22,23 @@ resource "oci_load_balancer_load_balancer" "openshift_api_int_lb" {
   defined_tags = var.defined_tags
 }
 
-resource "oci_load_balancer_load_balancer" "openshift_api_apps_lb" {
+resource "oci_load_balancer_load_balancer" "openshift_api_lb" {
   compartment_id             = var.compartment_ocid
-  display_name               = "${var.cluster_name}-openshift_api_apps_lb"
+  display_name               = "${var.cluster_name}-openshift_api_lb"
+  shape                      = "flexible"
+  subnet_ids                 = var.enable_private_dns ? [var.op_subnet_private_opc] : [var.op_subnet_public]
+  is_private                 = var.enable_private_dns ? true : false
+  network_security_group_ids = [var.op_network_security_group_cluster_lb_nsg]
+  shape_details {
+    maximum_bandwidth_in_mbps = var.load_balancer_shape_details_maximum_bandwidth_in_mbps
+    minimum_bandwidth_in_mbps = var.load_balancer_shape_details_minimum_bandwidth_in_mbps
+  }
+  defined_tags = var.defined_tags
+}
+
+resource "oci_load_balancer_load_balancer" "openshift_apps_lb" {
+  compartment_id             = var.compartment_ocid
+  display_name               = "${var.cluster_name}-openshift_apps_lb"
   shape                      = "flexible"
   subnet_ids                 = var.enable_private_dns ? [var.op_subnet_private_opc] : [var.op_subnet_public]
   is_private                 = var.enable_private_dns ? true : false

--- a/terraform-stacks/shared_modules/lb/output.tf
+++ b/terraform-stacks/shared_modules/lb/output.tf
@@ -4,8 +4,12 @@ output "op_lb_openshift_api_int_lb" {
   value = try(oci_load_balancer_load_balancer.openshift_api_int_lb.id, null)
 }
 
-output "op_lb_openshift_api_apps_lb" {
-  value = try(oci_load_balancer_load_balancer.openshift_api_apps_lb.id, null)
+output "op_lb_openshift_api_lb" {
+  value = try(oci_load_balancer_load_balancer.openshift_api_lb.id, null)
+}
+
+output "op_lb_openshift_apps_lb" {
+  value = try(oci_load_balancer_load_balancer.openshift_apps_lb.id, null)
 }
 
 // Output the IP addresses
@@ -14,8 +18,12 @@ output "op_lb_openshift_api_int_lb_ip_addr" {
   value = try(oci_load_balancer_load_balancer.openshift_api_int_lb.ip_address_details[0].ip_address, null)
 }
 
-output "op_lb_openshift_api_apps_lb_ip_addr" {
-  value = try(oci_load_balancer_load_balancer.openshift_api_apps_lb.ip_address_details[0].ip_address, null)
+output "op_lb_openshift_api_lb_ip_addr" {
+  value = try(oci_load_balancer_load_balancer.openshift_api_lb.ip_address_details[0].ip_address, null)
+}
+
+output "op_lb_openshift_apps_lb_ip_addr" {
+  value = try(oci_load_balancer_load_balancer.openshift_apps_lb.ip_address_details[0].ip_address, null)
 }
 
 // Output the backend set names


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Summary
Updated the terraform code to create separate LoadBalancer for *.apps (ingress).

## Purpose
Customers want to keep the separate LoadBalancer for API and Ingress traffic in terms of Security Isolation, Network Performance and Scalability, Compliance and Access Control. 
- API Endpoint: The OpenShift API is highly sensitive. It’s used for cluster management, authentication, and critical control-plane operations. Exposure to public networks increases attack surface for brute-force, DoS, or exploit attempts.
- Apps Endpoint: The *.apps.<cluster>.<domain> routes are for user applications and workloads, which typically have less strict access control.
- Separation allows:
   - Stricter firewall/security policies on API LB.
   - Option to restrict API LB to internal or VPN-only access.
   - DDoS protection and advanced WAF just for API without impacting app ingress.
- API Traffic is low-volume but critical; apps traffic can be high-volume and bursty (web apps, user traffic).
- Separate LBs prevent a traffic surge in user applications from impacting control-plane/API availability.
- Some organizations require strict audit and access controls on management endpoints.
- Separating LBs helps restrict access to the API (by IP allow-lists, VPNs, etc.) while still making apps publicly accessible.

## Description of Changes
The `compute`, `dns`, and `lb` modules have been updated to create a separate Load Balancer for `*.apps`. The DNS record now points to the new Load Balancer, and the appropriate backends have been associated for both HTTP and HTTPS traffic.

Additionally, the code under `terraform-stacks/add-nodes/` and `terraform-stacks/create-cluster/` has been updated to handle Load Balancer creation and ensure that any new node added as a Day-2 operation is correctly associated with the appropriate Load Balancer backend.