### PR TITLE
Release v1.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = bash
 
-PKG_VERSION ?= v1.4.1
+PKG_VERSION ?= v1.4.2
 OCI_DRIVER_VERSION ?= v1.32.0
 
 PRE_COMMIT := $(shell command -v pre-commit 2> /dev/null)

--- a/custom_manifests/manifests/01-oci-csi.yml
+++ b/custom_manifests/manifests/01-oci-csi.yml
@@ -517,17 +517,17 @@ parameters:
 
 ---
 
-# # https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/volume-snapshot-and-restore-using-csi.md
-# apiVersion: snapshot.storage.k8s.io/v1
-# kind: VolumeSnapshotClass
-# metadata:
-#   name: oci-snapshot
-#   annotations:
-#     snapshot.storage.kubernetes.io/is-default-class: "true"
-# driver: blockvolume.csi.oraclecloud.com
-# parameters:
-#   backupType: full
-# deletionPolicy: Delete
+# https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/volume-snapshot-and-restore-using-csi.md
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: oci-snapshot
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: blockvolume.csi.oraclecloud.com
+parameters:
+  backupType: full
+deletionPolicy: Delete
 
 ---
 

--- a/custom_manifests/oci-ccm-csi-drivers/v1.32.0-UHP/01-oci-csi.yml
+++ b/custom_manifests/oci-ccm-csi-drivers/v1.32.0-UHP/01-oci-csi.yml
@@ -532,17 +532,17 @@ reclaimPolicy: Delete
 
 ---
 
-# # https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/volume-snapshot-and-restore-using-csi.md
-# apiVersion: snapshot.storage.k8s.io/v1
-# kind: VolumeSnapshotClass
-# metadata:
-#   name: oci-snapshot
-#   annotations:
-#     snapshot.storage.kubernetes.io/is-default-class: "true"
-# driver: blockvolume.csi.oraclecloud.com
-# parameters:
-#   backupType: full
-# deletionPolicy: Delete
+# https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/volume-snapshot-and-restore-using-csi.md
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: oci-snapshot
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: blockvolume.csi.oraclecloud.com
+parameters:
+  backupType: full
+deletionPolicy: Delete
 
 ---
 

--- a/custom_manifests/oci-ccm-csi-drivers/v1.32.0/01-oci-csi.yml
+++ b/custom_manifests/oci-ccm-csi-drivers/v1.32.0/01-oci-csi.yml
@@ -517,17 +517,17 @@ parameters:
 
 ---
 
-# # https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/volume-snapshot-and-restore-using-csi.md
-# apiVersion: snapshot.storage.k8s.io/v1
-# kind: VolumeSnapshotClass
-# metadata:
-#   name: oci-snapshot
-#   annotations:
-#     snapshot.storage.kubernetes.io/is-default-class: "true"
-# driver: blockvolume.csi.oraclecloud.com
-# parameters:
-#   backupType: full
-# deletionPolicy: Delete
+# https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/volume-snapshot-and-restore-using-csi.md
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: oci-snapshot
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: blockvolume.csi.oraclecloud.com
+parameters:
+  backupType: full
+deletionPolicy: Delete
 
 ---
 

--- a/terraform-stacks/README.md
+++ b/terraform-stacks/README.md
@@ -85,9 +85,9 @@ Create the OCI resources for an OpenShift cluster on OCI and facilitate the inst
     - Count: 3
     - Shape: VM.Standard.E5.Flex
     - OCPU: 6
-    - Memory: 16 GB
+    - Memory: 32 GB
     - Boot Volume
-        - Size: 1024 GB
+        - Size: 300 GB
         - VPUs/GB: 30
 
 #### OCI Resources
@@ -166,9 +166,9 @@ Create the OCI resources for an OpenShift cluster on OCI and facilitate the inst
     - Count: 3
     - Shape: VM.Standard.E5.Flex
     - OCPU: 6
-    - Memory: 16 GB
+    - Memory: 32 GB
     - Boot Volume
-        - Size: 100 GB
+        - Size: 300 GB
         - VPUs/GB: 30
 
 #### Compact Bare Metal

--- a/terraform-stacks/add-nodes/schema.yaml
+++ b/terraform-stacks/add-nodes/schema.yaml
@@ -223,22 +223,16 @@ variables:
   compute_shape:
     type: string
     title: Compute Shape
-    description: Compute Instance shape of compute nodes. For more detail regarding supported shapes, please visit https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/overview.htm#supported-shapes
-    default: "VM.Standard.E5.Flex"
     required: true
 
   compute_count:
     type: integer
     title: Compute Node Count
-    description: The number of compute nodes to add to the cluster. The default value is 1.
     required: true
-    default: 1
 
   compute_ocpu:
     type: integer
     title: Compute Node OCPU
-    description: The number of OCPUs available for the shape of each compute node. The default value is 6.
-    default: 6
     minimum: 1
     maximum: 144
     required: true
@@ -246,8 +240,6 @@ variables:
   compute_memory:
     type: integer
     title: Compute Node Memory
-    description: The amount of memory available for the shape of each compute node, in gigabytes. The default value is 16.
-    default: 16
     minimum: 1
     maximum: 1760
     required: true
@@ -255,8 +247,6 @@ variables:
   compute_boot_size:
     type: integer
     title: Compute Node Boot Volume
-    description: The size of the boot volume of each compute node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 100 GB.
-    default: 100
     minimum: 50
     maximum: 32768
     required: true
@@ -264,8 +254,6 @@ variables:
   compute_boot_volume_vpus_per_gb:
     type: integer
     title: Compute Node VPU
-    description: The number of volume performance units (VPUs) that will be applied to this volume per GB of each compute node. The default value is 30.
-    default: 30
     minimum: 10
     maximum: 120
     multipleOf: 10

--- a/terraform-stacks/add-nodes/schema.yaml
+++ b/terraform-stacks/add-nodes/schema.yaml
@@ -1,11 +1,7 @@
-#
-# Copyright (c) 2024 Oracle and/or its affiliates. Licensed under the Universal Permissive License (UPL), Version 1.0. See LICENSE for more details.
-#
-
-title: Adding Nodes to OpenShift Cluster on OCI
+title: Add Nodes to OpenShift Cluster on OCI - v1.4.1
 description: A Terraform Stack for creating resources required for adding nodes to OpenShift Cluster on OCI
-schemaVersion: 1.1.0
-version: "20241106"
+schemaVersion: 1.4.1
+version: "20251010"
 locale: "en"
 
 

--- a/terraform-stacks/add-nodes/schema.yaml
+++ b/terraform-stacks/add-nodes/schema.yaml
@@ -1,7 +1,7 @@
-title: Add Nodes to OpenShift Cluster on OCI - v1.4.1
+title: Add Nodes to OpenShift Cluster on OCI - v1.4.2
 description: A Terraform Stack for creating resources required for adding nodes to OpenShift Cluster on OCI
-schemaVersion: 1.4.1
-version: "20251010"
+schemaVersion: 1.4.2
+version: "20250916"
 locale: "en"
 
 

--- a/terraform-stacks/add-nodes/variables.tf
+++ b/terraform-stacks/add-nodes/variables.tf
@@ -63,13 +63,13 @@ variable "compute_count" {
 variable "compute_shape" {
   default     = "VM.Standard.E5.Flex"
   type        = string
-  description = "Compute shape of the compute nodes. The default shape is BM.Standard3.64. For more detail regarding supported shapes, please visit https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/overview.htm#supported-shapes"
+  description = "Compute shape of the compute nodes. The default shape is VM.Standard.E5.Flex for VM setup and BM.Standard3.64 for BM setup. For more details regarding supported shapes, review OpenShift on OCI <a href='https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/overview.htm#supported-shapes'>supported shapes</a>."
 }
 
 variable "compute_ocpu" {
   default     = 6
   type        = number
-  description = "The number of OCPUs available for the shape of each compute node. The default value is 4. "
+  description = "The number of OCPUs available for the shape of each compute node."
 
   validation {
     condition     = var.compute_ocpu >= 1 && var.compute_ocpu <= 114
@@ -89,9 +89,9 @@ variable "compute_boot_volume_vpus_per_gb" {
 }
 
 variable "compute_memory" {
-  default     = 16
+  default     = 32
   type        = number
-  description = "The amount of memory available for the shape of each compute node, in gigabytes. The default value is 16."
+  description = "The amount of memory available for the shape of each compute node, in gigabytes."
 
   validation {
     condition     = var.compute_memory >= 1 && var.compute_memory <= 1760
@@ -100,9 +100,9 @@ variable "compute_memory" {
 }
 
 variable "compute_boot_size" {
-  default     = 100
+  default     = 300
   type        = number
-  description = "The size of the boot volume of each compute node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 100 GB."
+  description = "The size of the boot volume of each compute node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB)."
 
   validation {
     condition     = var.compute_boot_size >= 50 && var.compute_boot_size <= 32768

--- a/terraform-stacks/add-nodes/version.tf
+++ b/terraform-stacks/add-nodes/version.tf
@@ -1,3 +1,3 @@
 locals {
-  stack_version = "v1.4.1"
+  stack_version = "v1.4.2"
 }

--- a/terraform-stacks/create-cluster/schema.yaml
+++ b/terraform-stacks/create-cluster/schema.yaml
@@ -1,11 +1,7 @@
-#
-# Copyright (c) 2019-2020 Oracle and/or its affiliates. All rights reserved.
-#
-
-title: OpenShift on OCI
+title: OpenShift Cluster on OCI - v1.4.1
 description: A Terraform Stack for creating resources required for installing OpenShift on OCI
-schemaVersion: 1.2.0
-version: "20250602"
+schemaVersion: 1.4.1
+version: "20251010"
 locale: "en"
 
 variableGroups:

--- a/terraform-stacks/create-cluster/schema.yaml
+++ b/terraform-stacks/create-cluster/schema.yaml
@@ -1,7 +1,7 @@
-title: OpenShift Cluster on OCI - v1.4.1
+title: OpenShift Cluster on OCI - v1.4.2
 description: A Terraform Stack for creating resources required for installing OpenShift on OCI
-schemaVersion: 1.4.1
-version: "20251010"
+schemaVersion: 1.4.2
+version: "20250916"
 locale: "en"
 
 variableGroups:

--- a/terraform-stacks/create-cluster/schema.yaml
+++ b/terraform-stacks/create-cluster/schema.yaml
@@ -364,22 +364,17 @@ variables:
   compute_shape:
     type: string
     title: Compute Shape
-    description: Compute Instance shape of compute nodes. For more details, review OpenShift on OCI <a href='https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/overview.htm#supported-shapes'>supported shapes</a>
     default: "VM.Standard.E5.Flex"
     required: true
 
   compute_count:
     type: integer
     title: Compute Node Count
-    description: The number of compute nodes in the cluster. The default value is 3.
     required: true
-    default: 3
 
   compute_ocpu:
     type: integer
     title: Compute Node OCPU
-    description: The number of OCPUs available for the shape of each compute node. The default value is 6.
-    default: 6
     minimum: 1
     maximum: 144
     required: true
@@ -387,8 +382,6 @@ variables:
   compute_memory:
     type: integer
     title: Compute Node Memory
-    description: The amount of memory available for the shape of each compute node, in gigabytes. The default value is 16.
-    default: 16
     minimum: 1
     maximum: 1760
     required: true
@@ -396,8 +389,6 @@ variables:
   compute_boot_size:
     type: integer
     title: Compute Node Boot Volume
-    description: The size of the boot volume of each compute node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 100 GB.
-    default: 100
     minimum: 50
     maximum: 32768
     required: true
@@ -405,8 +396,6 @@ variables:
   compute_boot_volume_vpus_per_gb:
     type: integer
     title: Compute Node VPU
-    description: The number of volume performance units (VPUs) that will be applied to this volume per GB of each compute node. The default value is 30.
-    default: 30
     minimum: 10
     maximum: 120
     multipleOf: 10

--- a/terraform-stacks/create-cluster/variables.tf
+++ b/terraform-stacks/create-cluster/variables.tf
@@ -227,7 +227,7 @@ variable "compute_count" {
 variable "compute_ocpu" {
   default     = 6
   type        = number
-  description = "The number of OCPUs for each compute node. The default value is 6. For BM shapes, this value is ignored and determined by the shape selected."
+  description = "The number of OCPUs for each compute node. For BM shapes, this value is ignored and determined by the shape selected."
   validation {
     condition     = var.compute_ocpu >= 1 && var.compute_ocpu <= 114
     error_message = "The compute_ocpu value must be between 1 and 114."
@@ -235,9 +235,9 @@ variable "compute_ocpu" {
 }
 
 variable "compute_memory" {
-  default     = 16
+  default     = 32
   type        = number
-  description = "The amount of memory available for the shape of each compute node, in gigabytes. The default value is 16. For BM shapes, this value is ignored and determined by the shape selected."
+  description = "The amount of memory available for the shape of each compute node, in gigabytes.For BM shapes, this value is ignored and determined by the shape selected."
   validation {
     condition     = var.compute_memory >= 1 && var.compute_memory <= 1760
     error_message = "The compute_memory value must be between the value of compute_ocpu and 1760."
@@ -245,9 +245,9 @@ variable "compute_memory" {
 }
 
 variable "compute_boot_size" {
-  default     = 100
+  default     = 300
   type        = number
-  description = "The size of the boot volume of each compute node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB). The default value is 100 GB."
+  description = "The size of the boot volume of each compute node in GBs. The minimum value is 50 GB and the maximum value is 32,768 GB (32 TB)."
   validation {
     condition     = var.compute_boot_size >= 50 && var.compute_boot_size <= 32768
     error_message = "The compute_boot_size value must be between 50 and 32768."
@@ -257,7 +257,7 @@ variable "compute_boot_size" {
 variable "compute_boot_volume_vpus_per_gb" {
   default     = 30
   type        = number
-  description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each compute node. The default value is 30. "
+  description = "The number of volume performance units (VPUs) that will be applied to this volume per GB of each compute node."
   validation {
     condition     = var.compute_boot_volume_vpus_per_gb >= 10 && var.compute_boot_volume_vpus_per_gb <= 120 && var.compute_boot_volume_vpus_per_gb % 10 == 0
     error_message = "The compute_boot_volume_vpus_per_gb value must be between 10 and 120, and must be a multiple of 10."

--- a/terraform-stacks/create-cluster/version.tf
+++ b/terraform-stacks/create-cluster/version.tf
@@ -1,3 +1,3 @@
 locals {
-  stack_version = "v1.4.1"
+  stack_version = "v1.4.2"
 }

--- a/terraform-stacks/create-instance-role-tags/schema.yaml
+++ b/terraform-stacks/create-instance-role-tags/schema.yaml
@@ -1,11 +1,7 @@
-#
-# Copyright (c) 2019-2020 Oracle and/or its affiliates. All rights reserved.
-#
-
-title: OpenShift on OCI Instance Role Tags
+title: OpenShift on OCI Instance Role Tags - v1.4.1
 description: A Terraform Stack for creating OpenShift Instance Role Tags
-schemaVersion: 1.0.0
-version: "20241019"
+schemaVersion: 1.4.1
+version: "20251010"
 locale: "en"
 
 variableGroups:

--- a/terraform-stacks/create-instance-role-tags/schema.yaml
+++ b/terraform-stacks/create-instance-role-tags/schema.yaml
@@ -1,7 +1,7 @@
-title: OpenShift on OCI Instance Role Tags - v1.4.1
+title: OpenShift on OCI Instance Role Tags - v1.4.2
 description: A Terraform Stack for creating OpenShift Instance Role Tags
-schemaVersion: 1.4.1
-version: "20251010"
+schemaVersion: 1.4.2
+version: "20250916"
 locale: "en"
 
 variableGroups:

--- a/terraform-stacks/create-instance-role-tags/version.tf
+++ b/terraform-stacks/create-instance-role-tags/version.tf
@@ -1,3 +1,3 @@
 locals {
-  stack_version = "v1.4.1"
+  stack_version = "v1.4.2"
 }

--- a/terraform-stacks/create-resource-attribution-tags/schema.yaml
+++ b/terraform-stacks/create-resource-attribution-tags/schema.yaml
@@ -1,11 +1,7 @@
-#
-# Copyright (c) 2019-2020 Oracle and/or its affiliates. All rights reserved.
-#
-
-title: OpenShift on OCI Resource Attribution Tags
+title: OpenShift on OCI Resource Attribution Tags - v1.4.1
 description: A Terraform Stack for creating OpenShift Resource Attribution Tags.
-schemaVersion: 1.1.0
-version: "20230524"
+schemaVersion: 1.4.1
+version: "20251010"
 locale: "en"
 
 variableGroups:

--- a/terraform-stacks/create-resource-attribution-tags/schema.yaml
+++ b/terraform-stacks/create-resource-attribution-tags/schema.yaml
@@ -1,7 +1,7 @@
-title: OpenShift on OCI Resource Attribution Tags - v1.4.1
+title: OpenShift on OCI Resource Attribution Tags - v1.4.2
 description: A Terraform Stack for creating OpenShift Resource Attribution Tags.
-schemaVersion: 1.4.1
-version: "20251010"
+schemaVersion: 1.4.2
+version: "20250916"
 locale: "en"
 
 variableGroups:

--- a/terraform-stacks/create-resource-attribution-tags/version.tf
+++ b/terraform-stacks/create-resource-attribution-tags/version.tf
@@ -1,3 +1,3 @@
 locals {
-  stack_version = "v1.4.1"
+  stack_version = "v1.4.2"
 }

--- a/terraform-stacks/shared_modules/meta/output.tf
+++ b/terraform-stacks/shared_modules/meta/output.tf
@@ -27,5 +27,5 @@ output "node_distribution_summary" {
 }
 
 output "region_metadata" {
-  value = local.region_metadata == "error" ? "" : jsonencode(local.region_metadata)
+  value = local.metadata_available ? jsonencode(local.region_metadata) : ""
 }

--- a/terraform-stacks/shared_modules/meta/region-meta.tf
+++ b/terraform-stacks/shared_modules/meta/region-meta.tf
@@ -1,20 +1,19 @@
 # fetch the metadata of regionInfo from IMDS
 data "external" "instance_regionInfo" {
   program = ["bash", "-c", <<EOT
-set -e
-METADATA=$(curl -s -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/regionInfo)
-# Simple check if output starts with '{' to roughly verify JSON format.
-# On non-OCI instances, the curl may return an error HTML page instead of JSON. In this case, the script with treat the region as non-restricted.
+METADATA=$(curl -s --connect-timeout 5 --max-time 10 -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/regionInfo)
 if [[ "$METADATA" == \{* ]]; then
   echo "$METADATA"
 else
-  # Return an error string if the response is invalid or empty
-  echo "error"
+  echo "{}"
 fi
+exit 0
+
 EOT
   ]
 }
 
 locals {
-  region_metadata = try(data.external.instance_regionInfo.result, "error")
+  region_metadata    = try(data.external.instance_regionInfo.result, {})
+  metadata_available = lookup(local.region_metadata, "realmDomainComponent", "error") != "error"
 }


### PR DESCRIPTION
## Changes and Improvements

#### 1. Increase default resources (RAM and boot volume size) for Compute nodes
- The updated values will cause the automatic node role assignment process during Agent-based installations (or when node roles are otherwise not explicitly assigned) to properly assign node roles to control-plane and compute instances when using the default values.
  - compute_memory increased from 16 GB to 32 GB
  - compute_boot_size increased from 100 GB to 300 GB

#### 2. Include VolumeSnapshotClass for Block Volumes with other OCI CSI manifests


## Bug Fixes

#### 1. Fix OCI_REGION_METADATA retrieval
- Retrieve regionInfo from the instance metadata URL (http://169.254.169.254/opc/v2/instance/regionInfo) no longer fails when run on hosts without access to the IMDS endpoint


## Documentation Updates

- The README for OpenShift Virtualization has been updated to reflect the latest status and installation procedures
- Added versions (e.g. v1.4.2) to the stack schemas

---

## Contributors & Attribution

- @dfoster-oracle 
- @jiayzhon

---